### PR TITLE
New Deckset dev certificate

### DIFF
--- a/Deckset/Deckset.download.recipe
+++ b/Deckset/Deckset.download.recipe
@@ -43,7 +43,7 @@
             <key>input_path</key>
             <string>%pathname%/Deckset.app</string>
             <key>requirement</key>
-            <string>anchor apple generic and identifier "com.unsignedinteger.Deckset-Paddle" and (certificate leaf[field.1.2.840.113635.100.6.1.9] /* exists */ or certificate 1[field.1.2.840.113635.100.6.2.6] /* exists */ and certificate leaf[field.1.2.840.113635.100.6.1.13] /* exists */ and certificate leaf[subject.OU] = "53V65KL474")</string>
+            <string>anchor apple generic and identifier "com.unsignedinteger.Deckset-Paddle" and (certificate leaf[field.1.2.840.113635.100.6.1.9] /* exists */ or certificate 1[field.1.2.840.113635.100.6.2.6] /* exists */ and certificate leaf[field.1.2.840.113635.100.6.1.13] /* exists */ and certificate leaf[subject.OU] = "287LWMYEQ7")</string>
           </dict>
         </dict>
     </array>


### PR DESCRIPTION
Deckset > 2.0.27 uses a new Apple developer certificate (id "287LWMYEQ7" vs. the previous "53V65KL474").