### PR TITLE
Updating macadmins-extension.munki.recipy. This should allow recipe o…

### DIFF
--- a/osquery-extension/macadmins-extension.munki.recipe
+++ b/osquery-extension/macadmins-extension.munki.recipe
@@ -8,10 +8,28 @@
 	<string>com.github.zentralpro.munki.macadmins-extension</string>
 	<key>Input</key>
 	<dict>
-		<key>MUNKI_REPO_SUBDIR</key>
-		<string>apps/%NAME%</string>
 		<key>NAME</key>
 		<string>macadmins_extension</string>
+		<key>MUNKI_REPO_SUBDIR</key>
+		<string>apps/%NAME%</string>
+        <key>pkginfo</key>
+        <dict>
+            <key>catalogs</key>
+            <array>
+                <string>Production</string>
+            </array>
+            <key>description</key>
+            <string>macadmins-extension, an osquery extension for endpoint engineers.
+            </string>
+            <key>display_name</key>
+            <string>macadmins_extension</string>
+            <key>unattended_install</key>
+            <true/>
+            <key>category</key>
+            <string>Utilities</string>
+            <key>tools</key>
+            <string>macadmins</string>
+		</dict>	
 	</dict>
 	<key>MinimumVersion</key>
 	<string>1.0.0</string>
@@ -24,24 +42,6 @@
 			<dict>
 				<key>additional_pkginfo</key>
 				<dict>
-					<key>catalogs</key>
-					<array>
-						<string>Production</string>
-					</array>
-					<key>category</key>
-					<string>Utilities</string>
-					<key>description</key>
-					<string>macadmins-extension, an osquery extension for endpoint engineers.
-Release Notes:
-%release_notes%</string>
-					<key>developer</key>
-					<string>macadmins</string>
-					<key>display_name</key>
-					<string>macadmins-extension</string>
-					<key>name</key>
-					<string>%NAME%</string>
-					<key>unattended_install</key>
-					<true/>
 				</dict>
 			</dict>
 			<key>Processor</key>

--- a/osquery-extension/macadmins-extension.munki.recipe
+++ b/osquery-extension/macadmins-extension.munki.recipe
@@ -20,7 +20,8 @@
             </array>
             <key>description</key>
             <string>macadmins-extension, an osquery extension for endpoint engineers.
-            </string>
+Release Notes:
+%release_notes%</string>
             <key>display_name</key>
             <string>macadmins_extension</string>
             <key>unattended_install</key>


### PR DESCRIPTION
Updating macadmins-extension.munki.recipe. This should allow recipe overrides to add catalog info to the final pkginfo