### PR TITLE
Add VECTOR_ARCH input to parameterize darwin arch

### DIFF
--- a/vector/vector.download.recipe
+++ b/vector/vector.download.recipe
@@ -12,6 +12,8 @@
             <string></string>
             <key>NAME</key>
             <string>vector</string>
+            <key>VECTOR_ARCH</key>
+            <string>x86_64</string>
         </dict>
         <key>MinimumVersion</key>
         <string>1.0.0</string>
@@ -27,7 +29,7 @@
                     <key>github_repo</key>
                     <string>timberio/vector</string>
                     <key>asset_regex</key>
-                    <string>vector-[\d+].\d{0,2}.\d{0,2}-x86_64-apple-darwin.tar.gz</string>
+                    <string>vector-[\d+].\d{0,2}.\d{0,2}-%VECTOR_ARCH%-apple-darwin.tar.gz</string>
                 </dict>
             </dict>
             <dict>

--- a/vector/vector.pkg.recipe
+++ b/vector/vector.pkg.recipe
@@ -58,7 +58,7 @@
                 <key>Arguments</key>
                 <dict>
                     <key>source_path</key>
-                    <string>%RECIPE_CACHE_DIR%/unpack/vector-x86_64-apple-darwin/bin/%NAME%</string>
+                    <string>%RECIPE_CACHE_DIR%/unpack/vector-%VECTOR_ARCH%-apple-darwin/bin/%NAME%</string>
                     <key>destination_path</key>
                     <string>%pkgroot%/usr/local/bin/vector</string>
                     <key>overwrite</key>


### PR DESCRIPTION
## Summary

Vector upstream stopped publishing `x86_64-apple-darwin` builds at v0.51.0 (no x86_64 in v0.51 through v0.55 as of May 2026). The current `asset_regex` in `vector.download.recipe` is hardcoded to `x86_64`, so the recipe always resolves to v0.50.0 (the last x86_64 release) regardless of the consuming fleet's architecture.

This PR adds a `VECTOR_ARCH` input variable (default `x86_64` for backward compatibility) and references it from:

- the `asset_regex` in `vector.download.recipe`
- the unpack `source_path` in `vector.pkg.recipe` (the tarball's top-level directory name embeds the same arch token)

Pattern matches what was just merged in #63, which variable-ized `asset_regex` for santa-lite.

## Usage

Fleets on Apple Silicon can opt in via a recipe override:

```yaml
Input:
  VECTOR_ARCH: arm64
```

Consumers who don't override anything keep the existing behavior (continue pinning to v0.50.0).

## Test plan

To be run on macOS before this PR is flipped ready-for-review:

- [ ] `autopkg run -v vector.munki -k VECTOR_ARCH=arm64` downloads `vector-0.55.0-arm64-apple-darwin.tar.gz` and produces a pkg containing the arm64 binary.
- [ ] `autopkg run -v vector.munki -k VECTOR_ARCH=x86_64` downloads `vector-0.50.0-x86_64-apple-darwin.tar.gz` (matches pre-change behavior).
- [ ] `autopkg run -v vector.munki` (no override) matches the `x86_64` case (backward compat for existing consumers).

## Refs

- vectordotdev/vector v0.51.0 release notes (macOS x86_64 builds removed).
- #63 (santa-lite `asset_regex` parameterization, same pattern).
