### PR TITLE
New santa-lite variants after artifact hosting change

### DIFF
--- a/santa-lite/santa-lite.download.recipe
+++ b/santa-lite/santa-lite.download.recipe
@@ -3,17 +3,19 @@
 <plist version="1.0">
 <dict>
 	<key>Description</key>
-	<string>Downloads the current version of North Pole Security's Santa from Github.
-Set INCLUDE_PRERELEASES to any non-empty string to also consider pre-release versions.
-For the Santa Lite variant, use com.github.autopkg.zentral.download.santa-lite, which fetches from the public nps-santa-lite GCS bucket.</string>
+	<string>Downloads the current version of North Pole Security's Santa Lite from the public nps-santa-lite Google Cloud Storage bucket.
+The version is discovered via the northpolesec/santa GitHub releases (matching the standard pkg) so we get authoritative semver-aware ordering, then the lite pkg URL is constructed deterministically. This assumes the lite build's version tag matches the standard release tag, which NPS has held to so far.
+Set INCLUDE_PRERELEASES to any non-empty string to also consider pre-release versions.</string>
 	<key>Identifier</key>
-	<string>com.github.autopkg.zentral.download.santa</string>
+	<string>com.github.autopkg.zentral.download.santa-lite</string>
 	<key>Input</key>
 	<dict>
 		<key>NAME</key>
-		<string>santa</string>
+		<string>santa-lite</string>
 		<key>INCLUDE_PRERELEASES</key>
 		<string></string>
+		<key>OBJECT_BASE_URL</key>
+		<string>https://storage.googleapis.com/nps-santa-lite</string>
 	</dict>
 	<key>MinimumVersion</key>
 	<string>0.6.1</string>
@@ -35,6 +37,13 @@ For the Santa Lite variant, use com.github.autopkg.zentral.download.santa-lite, 
 		<dict>
 			<key>Processor</key>
 			<string>URLDownloader</string>
+			<key>Arguments</key>
+			<dict>
+				<key>url</key>
+				<string>%OBJECT_BASE_URL%/santa-%version%-lite.pkg</string>
+				<key>filename</key>
+				<string>santa-%version%-lite.pkg</string>
+			</dict>
 		</dict>
 		<dict>
 			<key>Processor</key>

--- a/santa-lite/santa-lite.install.recipe
+++ b/santa-lite/santa-lite.install.recipe
@@ -1,0 +1,29 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>Description</key>
+	<string>Installs the current version of North Pole Security's Santa Lite from the public nps-santa-lite GCS bucket.</string>
+	<key>Identifier</key>
+	<string>com.github.autopkg.zentral.install.santa-lite</string>
+	<key>Input</key>
+	<dict>
+	</dict>
+	<key>MinimumVersion</key>
+	<string>0.6.1</string>
+	<key>ParentRecipe</key>
+	<string>com.github.autopkg.zentral.download.santa-lite</string>
+	<key>Process</key>
+	<array>
+		<dict>
+			<key>Processor</key>
+			<string>Installer</string>
+			<key>Arguments</key>
+			<dict>
+				<key>pkg_path</key>
+				<string>%pathname%</string>
+			</dict>
+		</dict>
+	</array>
+</dict>
+</plist>

--- a/santa-lite/santa-lite.munki.recipe
+++ b/santa-lite/santa-lite.munki.recipe
@@ -11,7 +11,7 @@
 		<key>MUNKI_REPO_SUBDIR</key>
 		<string>agents/santa-lite</string>
 		<key>NAME</key>
-		<string>santa-lite</string>
+		<string>santa</string>
 		<key>pkginfo</key>
 		<dict>
 			<key>blocking_applications</key>
@@ -24,7 +24,7 @@
 			<key>category</key>
 			<string>Management</string>
 			<key>description</key>
-			<string>Santa Lite keeps track of binaries or app bundles that are naughty and nice.</string>
+			<string>Santa keeps track of binaries or app bundles that are naughty and nice.</string>
 			<key>developer</key>
 			<string>North Pole Security, Inc.</string>
 			<key>name</key>

--- a/santa-lite/santa-lite.munki.recipe
+++ b/santa-lite/santa-lite.munki.recipe
@@ -1,0 +1,246 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>Description</key>
+	<string>Downloads the current version of North Pole Security's Santa Lite from the public nps-santa-lite GCS bucket and imports into Munki.</string>
+	<key>Identifier</key>
+	<string>com.github.autopkg.zentral.munki.santa-lite</string>
+	<key>Input</key>
+	<dict>
+		<key>MUNKI_REPO_SUBDIR</key>
+		<string>agents/santa-lite</string>
+		<key>NAME</key>
+		<string>santa-lite</string>
+		<key>pkginfo</key>
+		<dict>
+			<key>blocking_applications</key>
+			<array>
+			</array>
+			<key>catalogs</key>
+			<array>
+				<string>testing</string>
+			</array>
+			<key>category</key>
+			<string>Management</string>
+			<key>description</key>
+			<string>Santa Lite keeps track of binaries or app bundles that are naughty and nice.</string>
+			<key>developer</key>
+			<string>North Pole Security, Inc.</string>
+			<key>name</key>
+			<string>%NAME%</string>
+			<key>unattended_install</key>
+			<true/>
+			<key>unattended_uninstall</key>
+			<true/>
+			<key>uninstall_method</key>
+			<string>uninstall_script</string>
+			<key>uninstall_script</key>
+			<string>#!/bin/bash
+
+## Script sourced from:
+## https://github.com/northpolesec/santa/blob/main/Conf/uninstall.sh
+
+# Uninstalls Santa from the boot volume, clearing up everything but logs/configs.
+# Unloads the kernel extension, services, and deletes component files.
+# If a user is logged in, also unloads the GUI agent.
+
+[ "$EUID" != 0 ] &amp;&amp; printf "%s\n" "This requires running as root/sudo." &amp;&amp; exit 1
+
+# This will block up to 60 seconds
+/Applications/Santa.app/Contents/MacOS/Santa --unload-system-extension
+
+# remove helper XPC services
+/bin/launchctl remove com.northpolesec.santa.bundleservice
+/bin/launchctl remove com.northpolesec.santa.metricservice
+/bin/launchctl remove com.northpolesec.santa.syncservice
+sleep 1
+user=$(/usr/bin/stat -f '%u' /dev/console)
+[[ -n "$user" ]] &amp;&amp; /bin/launchctl asuser ${user} /bin/launchctl remove com.northpolesec.santa
+# and to clean out the log config, although it won't write after wiping the binary
+/usr/bin/killall -HUP syslogd
+# delete artifacts on-disk
+/bin/rm -rf /Applications/Santa.app
+/bin/rm -f /Library/LaunchAgents/com.northpolesec.santa.plist
+/bin/rm -f /Library/LaunchDaemons/com.northpolesec.santa.bundleservice.plist
+/bin/rm -f /Library/LaunchDaemons/com.northpolesec.santa.metricservice.plist
+/bin/rm -f /Library/LaunchDaemons/com.northpolesec.santa.syncservice.plist
+/bin/rm -f /Library/LaunchAgents/com.google.santa.plist
+/bin/rm -f /Library/LaunchDaemons/com.google.santa.bundleservice.plist
+/bin/rm -f /Library/LaunchDaemons/com.google.santa.metricservice.plist
+/bin/rm -f /Library/LaunchDaemons/com.google.santa.syncservice.plist
+/bin/rm -f /private/etc/asl/com.northpolesec.santa.asl.conf
+/bin/rm -f /private/etc/newsyslog.d/com.northpolesec.santa.newsyslog.conf
+/bin/rm -f /usr/local/bin/santactl # just a symlink
+
+#forget receipt
+/usr/sbin/pkgutil --forget com.northpolesec.santa
+
+#uncomment to remove the config file and all databases, log files
+#/bin/rm -rf /var/db/santa
+#/bin/rm -f /var/log/santa*
+exit 0
+			</string>
+			<key>uninstallable</key>
+			<true/>
+		</dict>
+	</dict>
+	<key>MinimumVersion</key>
+	<string>2.7.6</string>
+	<key>ParentRecipe</key>
+	<string>com.github.autopkg.zentral.download.santa-lite</string>
+	<key>Process</key>
+	<array>
+		<dict>
+			<key>Processor</key>
+			<string>FlatPkgUnpacker</string>
+			<key>Arguments</key>
+			<dict>
+				<key>destination_path</key>
+				<string>%RECIPE_CACHE_DIR%/unpack</string>
+				<key>flat_pkg_path</key>
+				<string>%pathname%</string>
+			</dict>
+		</dict>
+		<dict>
+			<key>Processor</key>
+			<string>PkgPayloadUnpacker</string>
+			<key>Arguments</key>
+			<dict>
+				<key>destination_path</key>
+				<string>%RECIPE_CACHE_DIR%/payload</string>
+				<key>pkg_payload_path</key>
+				<string>%RECIPE_CACHE_DIR%/unpack/app.pkg/Payload</string>
+			</dict>
+		</dict>
+		<dict>
+			<key>Processor</key>
+			<string>PkgRootCreator</string>
+			<key>Arguments</key>
+			<dict>
+				<key>pkgroot</key>
+				<string>%RECIPE_CACHE_DIR%/faux_root</string>
+				<key>pkgdirs</key>
+				<dict>
+					<key>Applications</key>
+					<string>0775</string>
+				</dict>
+			</dict>
+		</dict>
+		<dict>
+			<key>Processor</key>
+			<string>FileMover</string>
+			<key>Arguments</key>
+			<dict>
+				<key>source</key>
+				<string>%RECIPE_CACHE_DIR%/payload/var/db/santa/migration/Santa.app</string>
+				<key>target</key>
+				<string>%RECIPE_CACHE_DIR%/faux_root/Applications/Santa.app</string>
+			</dict>
+		</dict>
+		<dict>
+			<key>Processor</key>
+			<string>Versioner</string>
+			<key>Arguments</key>
+			<dict>
+				<key>input_plist_path</key>
+				<string>%RECIPE_CACHE_DIR%/faux_root/Applications/Santa.app/Contents/Info.plist</string>
+				<key>plist_version_key</key>
+				<string>CFBundleVersion</string>
+			</dict>
+		</dict>
+		<dict>
+			<key>Processor</key>
+			<string>MunkiPkginfoMerger</string>
+			<key>Arguments</key>
+			<dict>
+				<key>additional_pkginfo</key>
+				<dict>
+					<key>version</key>
+					<string>%version%</string>
+					<key>installcheck_script</key>
+					<string>#!/bin/zsh
+
+minimum="%version%"
+SANTACTL="/Applications/Santa.app/Contents/MacOS/santactl"
+INFOPLIST="/Applications/Santa.app/Contents/Info.plist"
+PLISTBUDDY="/usr/libexec/PlistBuddy"
+
+# Make sure santactl exists and is executable
+if [[ ! -x "${SANTACTL}" ]]; then
+	echo "santactl not found or not executable"
+	exit 0
+fi
+
+# Get Santa version
+current="$("${PLISTBUDDY}" -c "Print :CFBundleVersion" "${INFOPLIST}" 2&gt;/dev/null || true)"
+if [[ -z "${current}" ]]; then
+	echo "ERROR: failed to read CFBundleVersion from ${INFOPLIST}"
+	exit 0
+fi
+
+# Version comparison
+autoload -Uz is-at-least
+if ! is-at-least "${minimum}" "${current}"; then
+	echo "Santa version ${current} does not meet the minimum version requirement of ${minimum}"
+	exit 0
+fi
+
+# Make sure Santa is running
+if ! "${SANTACTL}" status &gt;/dev/null 2&gt;&amp;1; then
+	echo "santactl status failed (daemon not responsive)"
+	exit 0
+fi
+
+exit 1</string>
+				</dict>
+			</dict>
+		</dict>
+		<dict>
+			<key>Processor</key>
+			<string>MunkiInstallsItemsCreator</string>
+			<key>Arguments</key>
+			<dict>
+				<key>derive_minimum_os_version</key>
+				<string>true</string>
+				<key>faux_root</key>
+				<string>%RECIPE_CACHE_DIR%/faux_root</string>
+				<key>installs_item_paths</key>
+				<array>
+					<string>/Applications/Santa.app</string>
+				</array>
+			</dict>
+		</dict>
+		<dict>
+			<key>Processor</key>
+			<string>MunkiPkginfoMerger</string>
+		</dict>
+		<dict>
+			<key>Processor</key>
+			<string>MunkiImporter</string>
+			<key>Arguments</key>
+			<dict>
+				<key>pkg_path</key>
+				<string>%pathname%</string>
+				<key>repo_subdirectory</key>
+				<string>%MUNKI_REPO_SUBDIR%</string>
+				<key>version_comparison_key</key>
+				<string>CFBundleVersion</string>
+			</dict>
+		</dict>
+		<dict>
+			<key>Processor</key>
+			<string>PathDeleter</string>
+			<key>Arguments</key>
+			<dict>
+				<key>path_list</key>
+				<array>
+					<string>%RECIPE_CACHE_DIR%/faux_root/</string>
+					<string>%RECIPE_CACHE_DIR%/payload/</string>
+					<string>%RECIPE_CACHE_DIR%/unpack</string>
+				</array>
+			</dict>
+		</dict>
+	</array>
+</dict>
+</plist>

--- a/santa/README.md
+++ b/santa/README.md
@@ -1,5 +1,5 @@
-# Google Santa
+# NorthPoleSec Santa
 
-Based on this [Santa recipe](https://github.com/autopkg/arubdesu-recipes/blob/master/santa/). Thanks!
+Adds an `installcheck_script` to help when the system extension is not in the expected state.
 
-We simply add an `installcheck_script` to help when the system extension is not in the expected state.
+The version fetched by the recipe set in the santa-lite folder omits the sleigh telemetry binary and network extension


### PR DESCRIPTION
reverted override-able asset regex added for introduction of santa-lite and instead made new recipes/enclosing folder whereas metadata about release versions still sourced from github releases. Code written/generated by claude, ran with `-vvv` and confirmed downloaded artifact is the actual `-lite` version (== no sleigh, no net sysext in payload)