### PR TITLE
Add multi-architecture support to yq recipes

### DIFF
--- a/yq/yq.download.recipe
+++ b/yq/yq.download.recipe
@@ -1,22 +1,39 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<!DOCTYPE plist PUBLIC "-//Apple//DTDPLIST1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
 <plist version="1.0">
     <dict>
         <key>Description</key>
-        <string>Download yq, a lightweight and portable command-line YAML processor. yq uses jq like syntax but works with yaml files as well as json.</string>
+        <string>Download yq, a lightweight and portable command-line YAML processor. yq uses jq like syntax but works with yaml files as well as json. Set ARCH to arm64 or x86_64.</string>
         <key>Identifier</key>
         <string>com.github.zentralpro.download.yq</string>
         <key>Input</key>
         <dict>
             <key>INCLUDE_PRERELEASES</key>
             <string></string>
+            <key>ARCH</key>
+            <string>arm64</string>
             <key>NAME</key>
             <string>yq</string>
         </dict>
         <key>MinimumVersion</key>
-        <string>1.0.0</string>
+        <string>2.7.6</string>
         <key>Process</key>
         <array>
+            <dict>
+                <key>Processor</key>
+                <string>FindAndReplace</string>
+                <key>Arguments</key>
+                <dict>
+                    <key>find</key>
+                    <string>x86_64</string>
+                    <key>input_string</key>
+                    <string>%ARCH%</string>
+                    <key>replace</key>
+                    <string>amd64</string>
+                    <key>result_output_var_name</key>
+                    <string>DOWNLOAD_ARCH</string>
+                </dict>
+            </dict>
             <dict>
                 <key>Processor</key>
                 <string>GitHubReleasesInfoProvider</string>
@@ -27,7 +44,7 @@
                     <key>github_repo</key>
                     <string>mikefarah/yq</string>
                     <key>asset_regex</key>
-                    <string>yq_darwin_amd64.tar.gz</string>
+                    <string>yq_darwin_%DOWNLOAD_ARCH%.tar.gz</string>
                 </dict>
             </dict>
             <dict>
@@ -36,7 +53,7 @@
                 <key>Arguments</key>
                 <dict>
                     <key>filename</key>
-                    <string>%NAME%.tar.gz</string>
+                    <string>%NAME%-%ARCH%.tar.gz</string>
                 </dict>
             </dict>
             <dict>

--- a/yq/yq.download.recipe
+++ b/yq/yq.download.recipe
@@ -1,37 +1,31 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<!DOCTYPE plist PUBLIC "-//Apple//DTDPLIST1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
 <plist version="1.0">
     <dict>
         <key>Description</key>
-        <string>Download yq, a lightweight and portable command-line YAML processor. yq uses jq like syntax but works with yaml files as well as json. Set ARCH to arm64 or x86_64.</string>
+        <string>DEPRECATED: This recipe has been replaced by com.github.kevinmcox.download.yq.
+
+Download yq, a lightweight and portable command-line YAML processor. yq uses jq like syntax but works with yaml files as well as json.</string>
         <key>Identifier</key>
         <string>com.github.zentralpro.download.yq</string>
         <key>Input</key>
         <dict>
             <key>INCLUDE_PRERELEASES</key>
             <string></string>
-            <key>ARCH</key>
-            <string>arm64</string>
             <key>NAME</key>
             <string>yq</string>
         </dict>
         <key>MinimumVersion</key>
-        <string>2.7.6</string>
+        <string>1.0.0</string>
         <key>Process</key>
         <array>
             <dict>
                 <key>Processor</key>
-                <string>FindAndReplace</string>
+                <string>DeprecationWarning</string>
                 <key>Arguments</key>
                 <dict>
-                    <key>find</key>
-                    <string>x86_64</string>
-                    <key>input_string</key>
-                    <string>%ARCH%</string>
-                    <key>replace</key>
-                    <string>amd64</string>
-                    <key>result_output_var_name</key>
-                    <string>DOWNLOAD_ARCH</string>
+                    <key>warning_message</key>
+                    <string>This recipe is deprecated. Please use com.github.kevinmcox.download.yq instead.</string>
                 </dict>
             </dict>
             <dict>
@@ -44,7 +38,7 @@
                     <key>github_repo</key>
                     <string>mikefarah/yq</string>
                     <key>asset_regex</key>
-                    <string>yq_darwin_%DOWNLOAD_ARCH%.tar.gz</string>
+                    <string>yq_darwin_amd64.tar.gz</string>
                 </dict>
             </dict>
             <dict>
@@ -53,7 +47,7 @@
                 <key>Arguments</key>
                 <dict>
                     <key>filename</key>
-                    <string>%NAME%-%ARCH%.tar.gz</string>
+                    <string>%NAME%.tar.gz</string>
                 </dict>
             </dict>
             <dict>

--- a/yq/yq.install.recipe
+++ b/yq/yq.install.recipe
@@ -3,16 +3,18 @@
 <plist version="1.0">
 <dict>
     <key>Description</key>
-    <string>Downloads, packages and installs the latest version of yq, a lightweight and portable command-line YAML processor. yq uses jq like syntax but works with yaml files as well as json. Installs to /usr/local/bin/yq</string>
+    <string>Downloads, packages and installs the latest version of yq, a lightweight and portable command-line YAML processor. yq uses jq like syntax but works with yaml files as well as json. Installs to /usr/local/bin/yq. Set ARCH to arm64 or x86_64.</string>
     <key>Identifier</key>
     <string>com.github.zentralpro.install.yq</string>
     <key>Input</key>
     <dict>
-			<key>NAME</key>
-			<string>yq</string>
-		</dict>
+        <key>ARCH</key>
+        <string>arm64</string>
+        <key>NAME</key>
+        <string>yq</string>
+    </dict>
     <key>MinimumVersion</key>
-    <string>1.0.0</string>
+    <string>2.7.6</string>
     <key>ParentRecipe</key>
     <string>com.github.zentralpro.pkg.yq</string>
     <key>Process</key>

--- a/yq/yq.install.recipe
+++ b/yq/yq.install.recipe
@@ -3,22 +3,31 @@
 <plist version="1.0">
 <dict>
     <key>Description</key>
-    <string>Downloads, packages and installs the latest version of yq, a lightweight and portable command-line YAML processor. yq uses jq like syntax but works with yaml files as well as json. Installs to /usr/local/bin/yq. Set ARCH to arm64 or x86_64.</string>
+    <string>DEPRECATED: This recipe has been replaced by com.github.kevinmcox.install.yq.
+
+Downloads, packages and installs the latest version of yq, a lightweight and portable command-line YAML processor. yq uses jq like syntax but works with yaml files as well as json. Installs to /usr/local/bin/yq</string>
     <key>Identifier</key>
     <string>com.github.zentralpro.install.yq</string>
     <key>Input</key>
     <dict>
-        <key>ARCH</key>
-        <string>arm64</string>
-        <key>NAME</key>
-        <string>yq</string>
-    </dict>
+			<key>NAME</key>
+			<string>yq</string>
+		</dict>
     <key>MinimumVersion</key>
-    <string>2.7.6</string>
+    <string>1.0.0</string>
     <key>ParentRecipe</key>
     <string>com.github.zentralpro.pkg.yq</string>
     <key>Process</key>
     <array>
+        <dict>
+            <key>Processor</key>
+            <string>DeprecationWarning</string>
+            <key>Arguments</key>
+            <dict>
+                <key>warning_message</key>
+                <string>This recipe is deprecated. Please use com.github.kevinmcox.install.yq instead.</string>
+            </dict>
+        </dict>
         <dict>
             <key>Processor</key>
             <string>Installer</string>

--- a/yq/yq.munki.recipe
+++ b/yq/yq.munki.recipe
@@ -3,23 +3,23 @@
 <plist version="1.0">
 <dict>
     <key>Description</key>
-    <string>Downloads, packages and installs the latest version of yq, a lightweight and portable command-line YAML processor. yq uses jq like syntax but works with yaml files as well as json. Installs to /usr/local/bin/yq</string>
+    <string>Downloads, packages and installs the latest version of yq, a lightweight and portable command-line YAML processor. yq uses jq like syntax but works with yaml files as well as json. Installs to /usr/local/bin/yq. Set ARCH to arm64 or x86_64.</string>
     <key>Identifier</key>
     <string>com.github.zentralpro.munki.yq</string>
     <key>ParentRecipe</key>
     <string>com.github.zentralpro.pkg.yq</string>
     <key>MinimumVersion</key>
-    <string>1.0.0</string>
+    <string>2.7.6</string>
     <key>Input</key>
     <dict>
+        <key>ARCH</key>
+        <string>arm64</string>
         <key>MUNKI_NAME</key>
         <string>%NAME%</string>
         <key>MUNKI_REPO_SUBDIR</key>
-        <string>utilities/%NAME%</string>
+        <string>utilities/%NAME%/%ARCH%</string>
         <key>MUNKI_CATEGORY</key>
         <string>Utilities</string>
-        <key>MUNKI_DEVELOPER</key>
-        <string>mikefarah</string>
         <key>DISPLAY_NAME</key>
         <string>yq</string>
         <key>pkginfo</key>
@@ -28,22 +28,50 @@
             <array>
                 <string>testing</string>
             </array>
-            <key>description</key>
-            <string>yq is a lightweight and portable command-line YAML processor. yq uses jq like syntax but works with yaml files as well as json. Installs to /usr/local/bin/yq</string>
-            <key>display_name</key>
-            <string>%DISPLAY_NAME%</string>
-            <key>name</key>
-            <string>%MUNKI_NAME%</string>
-            <key>unattended_install</key>
-            <true/>
             <key>category</key>
             <string>%MUNKI_CATEGORY%</string>
+            <key>description</key>
+            <string>yq is a lightweight and portable command-line YAML processor. yq uses jq like syntax but works with yaml files as well as json. Installs to /usr/local/bin/yq</string>
             <key>developer</key>
-            <string>%MUNKI_DEVELOPER%</string>
+            <string>Mike Farah</string>
+            <key>display_name</key>
+            <string>%DISPLAY_NAME%</string>
+            <key>minimum_os_version</key>
+            <string>12.0</string>
+            <key>name</key>
+            <string>%MUNKI_NAME%</string>
+            <key>supported_architectures</key>
+            <array>
+                <string>%ARCH%</string>
+            </array>
+            <key>unattended_install</key>
+            <true/>
+            <key>unattended_uninstall</key>
+            <true/>
+            <key>version_script</key>
+            <string>#!/bin/sh
+/usr/local/bin/yq --version | /usr/bin/grep -oE '[0-9]+(\.[0-9]+)+'</string>
         </dict>
     </dict>
     <key>Process</key>
     <array>
+        <dict>
+            <key>Processor</key>
+            <string>MunkiInstallsItemsCreator</string>
+            <key>Arguments</key>
+            <dict>
+                <key>faux_root</key>
+                <string>%RECIPE_CACHE_DIR%/pkgroot</string>
+                <key>installs_item_paths</key>
+                <array>
+                    <string>/usr/local/bin/yq</string>
+                </array>
+            </dict>
+        </dict>
+        <dict>
+            <key>Processor</key>
+            <string>MunkiPkginfoMerger</string>
+        </dict>
         <dict>
             <key>Processor</key>
             <string>MunkiImporter</string>
@@ -52,7 +80,20 @@
                 <key>repo_subdirectory</key>
                 <string>%MUNKI_REPO_SUBDIR%</string>
                 <key>pkg_path</key>
-                <string>%RECIPE_CACHE_DIR%/%NAME%-%version%.pkg</string>
+                <string>%pkg_path%</string>
+            </dict>
+        </dict>
+        <dict>
+            <key>Processor</key>
+            <string>PathDeleter</string>
+            <key>Comment</key>
+            <string>Cleaning up</string>
+            <key>Arguments</key>
+            <dict>
+                <key>path_list</key>
+                <array>
+                    <string>%RECIPE_CACHE_DIR%/pkgroot</string>
+                </array>
             </dict>
         </dict>
     </array>

--- a/yq/yq.munki.recipe
+++ b/yq/yq.munki.recipe
@@ -3,23 +3,25 @@
 <plist version="1.0">
 <dict>
     <key>Description</key>
-    <string>Downloads, packages and installs the latest version of yq, a lightweight and portable command-line YAML processor. yq uses jq like syntax but works with yaml files as well as json. Installs to /usr/local/bin/yq. Set ARCH to arm64 or x86_64.</string>
+    <string>DEPRECATED: This recipe has been replaced by com.github.kevinmcox.munki.yq.
+
+Downloads, packages and installs the latest version of yq, a lightweight and portable command-line YAML processor. yq uses jq like syntax but works with yaml files as well as json. Installs to /usr/local/bin/yq</string>
     <key>Identifier</key>
     <string>com.github.zentralpro.munki.yq</string>
     <key>ParentRecipe</key>
     <string>com.github.zentralpro.pkg.yq</string>
     <key>MinimumVersion</key>
-    <string>2.7.6</string>
+    <string>1.0.0</string>
     <key>Input</key>
     <dict>
-        <key>ARCH</key>
-        <string>arm64</string>
         <key>MUNKI_NAME</key>
         <string>%NAME%</string>
         <key>MUNKI_REPO_SUBDIR</key>
-        <string>utilities/%NAME%/%ARCH%</string>
+        <string>utilities/%NAME%</string>
         <key>MUNKI_CATEGORY</key>
         <string>Utilities</string>
+        <key>MUNKI_DEVELOPER</key>
+        <string>mikefarah</string>
         <key>DISPLAY_NAME</key>
         <string>yq</string>
         <key>pkginfo</key>
@@ -28,49 +30,30 @@
             <array>
                 <string>testing</string>
             </array>
-            <key>category</key>
-            <string>%MUNKI_CATEGORY%</string>
             <key>description</key>
             <string>yq is a lightweight and portable command-line YAML processor. yq uses jq like syntax but works with yaml files as well as json. Installs to /usr/local/bin/yq</string>
-            <key>developer</key>
-            <string>Mike Farah</string>
             <key>display_name</key>
             <string>%DISPLAY_NAME%</string>
-            <key>minimum_os_version</key>
-            <string>12.0</string>
             <key>name</key>
             <string>%MUNKI_NAME%</string>
-            <key>supported_architectures</key>
-            <array>
-                <string>%ARCH%</string>
-            </array>
             <key>unattended_install</key>
             <true/>
-            <key>unattended_uninstall</key>
-            <true/>
-            <key>version_script</key>
-            <string>#!/bin/sh
-/usr/local/bin/yq --version | /usr/bin/grep -oE '[0-9]+(\.[0-9]+)+'</string>
+            <key>category</key>
+            <string>%MUNKI_CATEGORY%</string>
+            <key>developer</key>
+            <string>%MUNKI_DEVELOPER%</string>
         </dict>
     </dict>
     <key>Process</key>
     <array>
         <dict>
             <key>Processor</key>
-            <string>MunkiInstallsItemsCreator</string>
+            <string>DeprecationWarning</string>
             <key>Arguments</key>
             <dict>
-                <key>faux_root</key>
-                <string>%RECIPE_CACHE_DIR%/pkgroot</string>
-                <key>installs_item_paths</key>
-                <array>
-                    <string>/usr/local/bin/yq</string>
-                </array>
+                <key>warning_message</key>
+                <string>This recipe is deprecated. Please use com.github.kevinmcox.munki.yq instead.</string>
             </dict>
-        </dict>
-        <dict>
-            <key>Processor</key>
-            <string>MunkiPkginfoMerger</string>
         </dict>
         <dict>
             <key>Processor</key>
@@ -80,20 +63,7 @@
                 <key>repo_subdirectory</key>
                 <string>%MUNKI_REPO_SUBDIR%</string>
                 <key>pkg_path</key>
-                <string>%pkg_path%</string>
-            </dict>
-        </dict>
-        <dict>
-            <key>Processor</key>
-            <string>PathDeleter</string>
-            <key>Comment</key>
-            <string>Cleaning up</string>
-            <key>Arguments</key>
-            <dict>
-                <key>path_list</key>
-                <array>
-                    <string>%RECIPE_CACHE_DIR%/pkgroot</string>
-                </array>
+                <string>%RECIPE_CACHE_DIR%/%NAME%-%version%.pkg</string>
             </dict>
         </dict>
     </array>

--- a/yq/yq.pkg.recipe
+++ b/yq/yq.pkg.recipe
@@ -1,24 +1,37 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<!DOCTYPE plist PUBLIC "-//Apple//DTDPLIST1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
 <plist version="1.0">
     <dict>
         <key>Description</key>
-        <string>Downloads and packages the latest version of yq, a lightweight and portable command-line YAML processor. yq uses jq like syntax but works with yaml files as well as json. Installs to /usr/local/bin/yq. Set ARCH to arm64 or x86_64.</string>
+        <string>DEPRECATED: This recipe has been replaced by com.github.kevinmcox.pkg.yq.
+
+Downloads and packages the latest version of yq, a lightweight and portable command-line YAML processor. yq uses jq like syntax but works with yaml files as well as json. Installs to /usr/local/bin/yq</string>
         <key>Identifier</key>
         <string>com.github.zentralpro.pkg.yq</string>
         <key>Input</key>
         <dict>
-            <key>ARCH</key>
-            <string>arm64</string>
             <key>NAME</key>
             <string>yq</string>
+            <key>PKG_ID</key>
+            <string>com.mikefarah.yq</string>
+            <key>PKG_VERSION</key>
+            <string>1.0.0</string>
         </dict>
         <key>MinimumVersion</key>
-        <string>2.7.6</string>
+        <string>1.0.0</string>
         <key>ParentRecipe</key>
         <string>com.github.zentralpro.download.yq</string>
         <key>Process</key>
         <array>
+            <dict>
+                <key>Processor</key>
+                <string>DeprecationWarning</string>
+                <key>Arguments</key>
+                <dict>
+                    <key>warning_message</key>
+                    <string>This recipe is deprecated. Please use com.github.kevinmcox.pkg.yq instead.</string>
+                </dict>
+            </dict>
             <dict>
                 <key>Processor</key>
                 <string>PkgRootCreator</string>
@@ -32,15 +45,9 @@
                         <string>0755</string>
                         <key>usr/local/bin/</key>
                         <string>0775</string>
-                        <key>usr/local/share/</key>
-                        <string>0755</string>
-                        <key>usr/local/share/man/</key>
-                        <string>0755</string>
-                        <key>usr/local/share/man/man1/</key>
-                        <string>0755</string>
                     </dict>
                     <key>pkgroot</key>
-                    <string>%RECIPE_CACHE_DIR%/pkgroot</string>
+                    <string>%RECIPE_CACHE_DIR%/%NAME%</string>
                 </dict>
             </dict>
             <dict>
@@ -62,22 +69,9 @@
                 <key>Arguments</key>
                 <dict>
                     <key>source_path</key>
-                    <string>%RECIPE_CACHE_DIR%/unpack/yq_darwin_%DOWNLOAD_ARCH%</string>
+                    <string>%RECIPE_CACHE_DIR%/unpack/yq_darwin_amd64</string>
                     <key>destination_path</key>
                     <string>%pkgroot%/usr/local/bin/yq</string>
-                    <key>overwrite</key>
-                    <true/>
-                </dict>
-            </dict>
-            <dict>
-                <key>Processor</key>
-                <string>Copier</string>
-                <key>Arguments</key>
-                <dict>
-                    <key>source_path</key>
-                    <string>%RECIPE_CACHE_DIR%/unpack/yq.1</string>
-                    <key>destination_path</key>
-                    <string>%pkgroot%/usr/local/share/man/man1/yq.1</string>
                     <key>overwrite</key>
                     <true/>
                 </dict>
@@ -97,17 +91,7 @@
                                 <key>mode</key>
                                 <string>0755</string>
                                 <key>path</key>
-                                <string>usr/local/bin/yq</string>
-                                <key>user</key>
-                                <string>root</string>
-                            </dict>
-                            <dict>
-                                <key>group</key>
-                                <string>wheel</string>
-                                <key>mode</key>
-                                <string>0644</string>
-                                <key>path</key>
-                                <string>usr/local/share/man/man1/yq.1</string>
+                                <string>usr</string>
                                 <key>user</key>
                                 <string>root</string>
                             </dict>
@@ -115,20 +99,21 @@
                         <key>id</key>
                         <string>com.github.mikefarah.yq</string>
                         <key>pkgname</key>
-                        <string>%NAME%-%ARCH%-%version%</string>
-                        <key>version</key>
-                        <string>%version%</string>
+                        <string>%NAME%-%version%</string>
                     </dict>
                 </dict>
             </dict>
             <dict>
                 <key>Processor</key>
                 <string>PathDeleter</string>
+                <key>Comment</key>
+                <string>Cleaning up</string>
                 <key>Arguments</key>
                 <dict>
                     <key>path_list</key>
                     <array>
                         <string>%RECIPE_CACHE_DIR%/unpack</string>
+                        <string>%pkgroot%</string>
                     </array>
                 </dict>
             </dict>

--- a/yq/yq.pkg.recipe
+++ b/yq/yq.pkg.recipe
@@ -1,22 +1,20 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<!DOCTYPE plist PUBLIC "-//Apple//DTDPLIST1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
 <plist version="1.0">
     <dict>
         <key>Description</key>
-        <string>Downloads and packages the latest version of yq, a lightweight and portable command-line YAML processor. yq uses jq like syntax but works with yaml files as well as json. Installs to /usr/local/bin/yq</string>
+        <string>Downloads and packages the latest version of yq, a lightweight and portable command-line YAML processor. yq uses jq like syntax but works with yaml files as well as json. Installs to /usr/local/bin/yq. Set ARCH to arm64 or x86_64.</string>
         <key>Identifier</key>
         <string>com.github.zentralpro.pkg.yq</string>
         <key>Input</key>
         <dict>
+            <key>ARCH</key>
+            <string>arm64</string>
             <key>NAME</key>
             <string>yq</string>
-            <key>PKG_ID</key>
-            <string>com.mikefarah.yq</string>
-            <key>PKG_VERSION</key>
-            <string>1.0.0</string>
         </dict>
         <key>MinimumVersion</key>
-        <string>1.0.0</string>
+        <string>2.7.6</string>
         <key>ParentRecipe</key>
         <string>com.github.zentralpro.download.yq</string>
         <key>Process</key>
@@ -34,9 +32,15 @@
                         <string>0755</string>
                         <key>usr/local/bin/</key>
                         <string>0775</string>
+                        <key>usr/local/share/</key>
+                        <string>0755</string>
+                        <key>usr/local/share/man/</key>
+                        <string>0755</string>
+                        <key>usr/local/share/man/man1/</key>
+                        <string>0755</string>
                     </dict>
                     <key>pkgroot</key>
-                    <string>%RECIPE_CACHE_DIR%/%NAME%</string>
+                    <string>%RECIPE_CACHE_DIR%/pkgroot</string>
                 </dict>
             </dict>
             <dict>
@@ -58,9 +62,22 @@
                 <key>Arguments</key>
                 <dict>
                     <key>source_path</key>
-                    <string>%RECIPE_CACHE_DIR%/unpack/yq_darwin_amd64</string>
+                    <string>%RECIPE_CACHE_DIR%/unpack/yq_darwin_%DOWNLOAD_ARCH%</string>
                     <key>destination_path</key>
                     <string>%pkgroot%/usr/local/bin/yq</string>
+                    <key>overwrite</key>
+                    <true/>
+                </dict>
+            </dict>
+            <dict>
+                <key>Processor</key>
+                <string>Copier</string>
+                <key>Arguments</key>
+                <dict>
+                    <key>source_path</key>
+                    <string>%RECIPE_CACHE_DIR%/unpack/yq.1</string>
+                    <key>destination_path</key>
+                    <string>%pkgroot%/usr/local/share/man/man1/yq.1</string>
                     <key>overwrite</key>
                     <true/>
                 </dict>
@@ -80,7 +97,17 @@
                                 <key>mode</key>
                                 <string>0755</string>
                                 <key>path</key>
-                                <string>usr</string>
+                                <string>usr/local/bin/yq</string>
+                                <key>user</key>
+                                <string>root</string>
+                            </dict>
+                            <dict>
+                                <key>group</key>
+                                <string>wheel</string>
+                                <key>mode</key>
+                                <string>0644</string>
+                                <key>path</key>
+                                <string>usr/local/share/man/man1/yq.1</string>
                                 <key>user</key>
                                 <string>root</string>
                             </dict>
@@ -88,21 +115,20 @@
                         <key>id</key>
                         <string>com.github.mikefarah.yq</string>
                         <key>pkgname</key>
-                        <string>%NAME%-%version%</string>
+                        <string>%NAME%-%ARCH%-%version%</string>
+                        <key>version</key>
+                        <string>%version%</string>
                     </dict>
                 </dict>
             </dict>
             <dict>
                 <key>Processor</key>
                 <string>PathDeleter</string>
-                <key>Comment</key>
-                <string>Cleaning up</string>
                 <key>Arguments</key>
                 <dict>
                     <key>path_list</key>
                     <array>
                         <string>%RECIPE_CACHE_DIR%/unpack</string>
-                        <string>%pkgroot%</string>
                     </array>
                 </dict>
             </dict>


### PR DESCRIPTION
- Multi-arch: Added ARCH input (arm64/x86_64) across all four recipes. A FindAndReplace step in the download recipe maps x86_64 → amd64 to match yq's GitHub asset naming and support Munki's supported_architectures with one variable.
- Man page: Pkg now installs yq.1 to /usr/local/share/man/man1/yq.1
- Pkg naming: pkgname now %NAME%-%ARCH%-%version% so both arches can coexist
- Munki:
  - MUNKI_REPO_SUBDIR includes %ARCH%, supported_architectures set to %ARCH%
  - Added version_script that extracts the semver from yq --version via grep -oE
  - Added MunkiInstallsItemsCreator as an alternative to the version_script
  - Added minimum_os_version 12.0 and unattended_uninstall
  - pkginfo keys alphabetized
- Cleanup lifecycle: pkgroot is now kept around at %RECIPE_CACHE_DIR%/pkgroot after the pkg recipe and only deleted at the end of the munki recipe (so MunkiInstallsItemsCreator can read it).
- Misc: bumped MinimumVersion to 2.7.6 (FindAndReplace requirement) across all four; removed unused PKG_ID/PKG_VERSION inputs from pkg recipe; normalized tabs → spaces in install recipe Input block; fixed DOCTYPE.