### PR TITLE
Use expected_authority_names in santa recipes

### DIFF
--- a/santa-lite/santa-lite.download.recipe
+++ b/santa-lite/santa-lite.download.recipe
@@ -56,7 +56,7 @@ Set INCLUDE_PRERELEASES to any non-empty string to also consider pre-release ver
 			<dict>
 				<key>input_path</key>
 				<string>%pathname%</string>
-				<key>requirement</key>
+				<key>expected_authority_names</key>
 				<array>
 					<string>Developer ID Installer: North Pole Security, Inc. (ZMCG7MLDV9)</string>
 					<string>Developer ID Certification Authority</string>

--- a/santa/santa.download.recipe
+++ b/santa/santa.download.recipe
@@ -47,7 +47,7 @@ For the Santa Lite variant, use com.github.autopkg.zentral.download.santa-lite, 
 			<dict>
 				<key>input_path</key>
 				<string>%pathname%</string>
-				<key>requirement</key>
+				<key>expected_authority_names</key>
 				<array>
 					<string>Developer ID Installer: North Pole Security, Inc. (ZMCG7MLDV9)</string>
 					<string>Developer ID Certification Authority</string>


### PR DESCRIPTION
`santa.download.recipe` and `santa-lite.download.recipe` passed an array of certificate authority names to the `CodeSignatureVerifier` `requirement` argument. `requirement` takes a single codesign requirement string and is not consulted when verifying an installer package, so the authority chain was never checked. Moving the array to `expected_authority_names` validates the full chain (`Developer ID Installer: North Pole Security, Inc. (ZMCG7MLDV9)` → `Developer ID Certification Authority` → `Apple Root CA`). The pkg and munki children inherit the verifier unchanged.

## Verification

`autopkg run -vv` — the change to the `CodeSignatureVerifier` output (before → after):

`% autopkg run -vv com.github.autopkg.zentral.download.santa`

```diff
--- before
+++ after
@@ -1,9 +1,9 @@
 CodeSignatureVerifier
-{'Input': {'input_path': '~/Library/AutoPkg/Cache/com.github.autopkg.zentral.download.santa/downloads/santa-2026.4.pkg',
-           'requirement': ['Developer ID Installer: North Pole Security, Inc. '
-                           '(ZMCG7MLDV9)',
-                           'Developer ID Certification Authority',
-                           'Apple Root CA']}}
+{'Input': {'expected_authority_names': ['Developer ID Installer: North Pole '
+                                        'Security, Inc. (ZMCG7MLDV9)',
+                                        'Developer ID Certification Authority',
+                                        'Apple Root CA'],
+           'input_path': '~/Library/AutoPkg/Cache/com.github.autopkg.zentral.download.santa/downloads/santa-2026.4.pkg'}}
 CodeSignatureVerifier: No value supplied for deep_verification, setting default value of: True
 CodeSignatureVerifier: Verifying installer package signature...
 CodeSignatureVerifier: Package "santa-2026.4.pkg":
@@ -30,4 +30,5 @@
 CodeSignatureVerifier:            68 C5 BE 91 B5 A1 10 01 F0 24
 CodeSignatureVerifier: 
 CodeSignatureVerifier: Signature is valid
+CodeSignatureVerifier: Authority name chain is valid
 {'Output': {}}
```

`% autopkg run -vv com.github.autopkg.zentral.download.santa-lite`

```diff
--- before
+++ after
@@ -1,9 +1,9 @@
 CodeSignatureVerifier
-{'Input': {'input_path': '~/Library/AutoPkg/Cache/com.github.autopkg.zentral.download.santa-lite/downloads/santa-2026.4-lite.pkg',
-           'requirement': ['Developer ID Installer: North Pole Security, Inc. '
-                           '(ZMCG7MLDV9)',
-                           'Developer ID Certification Authority',
-                           'Apple Root CA']}}
+{'Input': {'expected_authority_names': ['Developer ID Installer: North Pole '
+                                        'Security, Inc. (ZMCG7MLDV9)',
+                                        'Developer ID Certification Authority',
+                                        'Apple Root CA'],
+           'input_path': '~/Library/AutoPkg/Cache/com.github.autopkg.zentral.download.santa-lite/downloads/santa-2026.4-lite.pkg'}}
 CodeSignatureVerifier: No value supplied for deep_verification, setting default value of: True
 CodeSignatureVerifier: Verifying installer package signature...
 CodeSignatureVerifier: Package "santa-2026.4-lite.pkg":
@@ -30,4 +30,5 @@
 CodeSignatureVerifier:            68 C5 BE 91 B5 A1 10 01 F0 24
 CodeSignatureVerifier: 
 CodeSignatureVerifier: Signature is valid
+CodeSignatureVerifier: Authority name chain is valid
 {'Output': {}}
```
