### PR TITLE
initial turbo

### DIFF
--- a/turbo/Turbo.download.recipe
+++ b/turbo/Turbo.download.recipe
@@ -1,0 +1,82 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>Description</key>
+	<string>Downloads the selected Turbo pkg from Zentral's S3 download page.
+		Leave PRE_RELEASE as stable for the left Stable card, or set it to edge
+		for the Bleeding edge pre-release card.</string>
+	<key>Identifier</key>
+	<string>com.github.autopkg.zentral.turbo.download</string>
+	<key>Input</key>
+	<dict>
+		<key>NAME</key>
+		<string>Turbo</string>
+		<key>PRE_RELEASE</key>
+		<string>stable</string>
+		<key>Comment</key>
+		<string>PRE_RELEASE maps to the page card class: stable is the default release, edge is the Bleeding edge pre-release.</string>
+	</dict>
+	<key>MinimumVersion</key>
+	<string>1.0.0</string>
+	<key>Process</key>
+	<array>
+		<dict>
+			<key>Processor</key>
+			<string>URLTextSearcher</string>
+			<key>Arguments</key>
+			<dict>
+				<key>url</key>
+				<string>https://zentral-pro-services-public.s3.eu-central-1.amazonaws.com/turbo/index.html</string>
+				<key>re_pattern</key>
+				<string>&lt;a class="card %PRE_RELEASE%" href="(https://zentral-pro-services-public\.s3\.eu-central-1\.amazonaws\.com/turbo/Turbo-[0-9]+(?:\.[0-9]+)+\.pkg)"&gt;</string>
+				<key>result_output_var_name</key>
+				<string>download_url</string>
+			</dict>
+		</dict>
+		<dict>
+			<key>Processor</key>
+			<string>URLTextSearcher</string>
+			<key>Arguments</key>
+			<dict>
+				<key>url</key>
+				<string>https://zentral-pro-services-public.s3.eu-central-1.amazonaws.com/turbo/index.html</string>
+				<key>re_pattern</key>
+				<string>&lt;a class="card %PRE_RELEASE%" href="https://zentral-pro-services-public\.s3\.eu-central-1\.amazonaws\.com/turbo/Turbo-([0-9]+(?:\.[0-9]+)+)\.pkg"&gt;</string>
+				<key>result_output_var_name</key>
+				<string>version</string>
+			</dict>
+		</dict>
+		<dict>
+			<key>Processor</key>
+			<string>URLDownloader</string>
+			<key>Arguments</key>
+			<dict>
+				<key>url</key>
+				<string>%download_url%</string>
+				<key>filename</key>
+				<string>%NAME%-%version%.pkg</string>
+			</dict>
+		</dict>
+		<dict>
+			<key>Processor</key>
+			<string>EndOfCheckPhase</string>
+		</dict>
+		<dict>
+			<key>Processor</key>
+			<string>CodeSignatureVerifier</string>
+			<key>Arguments</key>
+			<dict>
+				<key>input_path</key>
+				<string>%pathname%</string>
+				<key>expected_authority_names</key>
+				<array>
+					<string>Developer ID Installer: Zentral Pro Services GmbH (WQ28ZDJ49Y)</string>
+					<string>Developer ID Certification Authority</string>
+					<string>Apple Root CA</string>
+				</array>
+			</dict>
+		</dict>
+	</array>
+</dict>
+</plist>

--- a/turbo/Turbo.install.recipe
+++ b/turbo/Turbo.install.recipe
@@ -1,0 +1,31 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>Description</key>
+	<string>Installs the selected Turbo pkg on this machine.</string>
+	<key>Identifier</key>
+	<string>com.github.autopkg.zentral.turbo.install</string>
+	<key>Input</key>
+	<dict>
+		<key>NAME</key>
+		<string>Turbo</string>
+	</dict>
+	<key>MinimumVersion</key>
+	<string>1.0.0</string>
+	<key>ParentRecipe</key>
+	<string>com.github.autopkg.zentral.turbo.pkg</string>
+	<key>Process</key>
+	<array>
+		<dict>
+			<key>Processor</key>
+			<string>Installer</string>
+			<key>Arguments</key>
+			<dict>
+				<key>pkg_path</key>
+				<string>%pkg_path%</string>
+			</dict>
+		</dict>
+	</array>
+</dict>
+</plist>

--- a/turbo/Turbo.munki.recipe
+++ b/turbo/Turbo.munki.recipe
@@ -1,0 +1,52 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>Description</key>
+	<string>Imports the selected Turbo pkg into Munki.</string>
+	<key>Identifier</key>
+	<string>com.github.autopkg.zentral.turbo.munki</string>
+	<key>Input</key>
+	<dict>
+		<key>MUNKI_REPO_SUBDIR</key>
+		<string></string>
+		<key>NAME</key>
+		<string>Turbo</string>
+		<key>pkginfo</key>
+		<dict>
+			<key>catalogs</key>
+			<array>
+				<string>testing</string>
+			</array>
+			<key>description</key>
+			<string>Turbo is a Zentral Pro Services app and command-line tooling that replaces the need for python to wrap Munki runs, among other features.</string>
+			<key>developer</key>
+			<string>Zentral Pro Services GmbH</string>
+			<key>display_name</key>
+			<string>Turbo</string>
+			<key>name</key>
+			<string>%NAME%</string>
+			<key>unattended_install</key>
+			<true/>
+		</dict>
+	</dict>
+	<key>MinimumVersion</key>
+	<string>1.0.0</string>
+	<key>ParentRecipe</key>
+	<string>com.github.autopkg.zentral.turbo.pkg</string>
+	<key>Process</key>
+	<array>
+		<dict>
+			<key>Processor</key>
+			<string>MunkiImporter</string>
+			<key>Arguments</key>
+			<dict>
+				<key>pkg_path</key>
+				<string>%pkg_path%</string>
+				<key>repo_subdirectory</key>
+				<string>%MUNKI_REPO_SUBDIR%</string>
+			</dict>
+		</dict>
+	</array>
+</dict>
+</plist>

--- a/turbo/Turbo.pkg.recipe
+++ b/turbo/Turbo.pkg.recipe
@@ -1,0 +1,33 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>Description</key>
+	<string>Copies the verified Turbo pkg into a pkg recipe output path.</string>
+	<key>Identifier</key>
+	<string>com.github.autopkg.zentral.turbo.pkg</string>
+	<key>Input</key>
+	<dict>
+		<key>NAME</key>
+		<string>Turbo</string>
+	</dict>
+	<key>MinimumVersion</key>
+	<string>1.0.0</string>
+	<key>ParentRecipe</key>
+	<string>com.github.autopkg.zentral.turbo.download</string>
+	<key>Process</key>
+	<array>
+		<dict>
+			<key>Processor</key>
+			<string>PkgCopier</string>
+			<key>Arguments</key>
+			<dict>
+				<key>source_pkg</key>
+				<string>%pathname%</string>
+				<key>pkg_path</key>
+				<string>%RECIPE_CACHE_DIR%/%NAME%-%version%.pkg</string>
+			</dict>
+		</dict>
+	</array>
+</dict>
+</plist>


### PR DESCRIPTION
could use more testing, but without --key PRE_RELEASE=edge (for bleeding-edge) .download successfully pulls and confirms the pkg is signed