### PR TITLE
Deprecate recipes Zentral no longer maintains

### DIFF
--- a/BlockBlock/BlockBlock.download.recipe
+++ b/BlockBlock/BlockBlock.download.recipe
@@ -18,6 +18,15 @@
     <key>Process</key>
     <array>
         <dict>
+            <key>Processor</key>
+            <string>DeprecationWarning</string>
+            <key>Arguments</key>
+            <dict>
+                <key>warning_message</key>
+                <string>This recipe is deprecated and is no longer maintained by Zentral. It may stop working at any time and will not receive further updates. If you rely on it and would like to take over maintenance, we'd be glad to help hand it off — please open an issue at https://github.com/autopkg/zentral-recipes/issues to get in touch.</string>
+            </dict>
+        </dict>
+        <dict>
             <key>Arguments</key>
             <dict>
                 <key>asset_regex</key>

--- a/Brim/Brim.download.recipe
+++ b/Brim/Brim.download.recipe
@@ -19,6 +19,15 @@
     <array>
         <dict>
             <key>Processor</key>
+            <string>DeprecationWarning</string>
+            <key>Arguments</key>
+            <dict>
+                <key>warning_message</key>
+                <string>This recipe is deprecated and is no longer maintained by Zentral. It may stop working at any time and will not receive further updates. If you rely on it and would like to take over maintenance, we'd be glad to help hand it off — please open an issue at https://github.com/autopkg/zentral-recipes/issues to get in touch.</string>
+            </dict>
+        </dict>
+        <dict>
+            <key>Processor</key>
             <string>GitHubReleasesInfoProvider</string>
             <key>Arguments</key>
             <dict>

--- a/Brim/Brim.install.recipe
+++ b/Brim/Brim.install.recipe
@@ -19,6 +19,15 @@
     <array>
         <dict>
             <key>Processor</key>
+            <string>DeprecationWarning</string>
+            <key>Arguments</key>
+            <dict>
+                <key>warning_message</key>
+                <string>This recipe is deprecated and is no longer maintained by Zentral. It may stop working at any time and will not receive further updates. If you rely on it and would like to take over maintenance, we'd be glad to help hand it off — please open an issue at https://github.com/autopkg/zentral-recipes/issues to get in touch.</string>
+            </dict>
+        </dict>
+        <dict>
+            <key>Processor</key>
             <string>InstallFromDMG</string>
 						<key>Arguments</key>
 						<dict>

--- a/Brim/Brim.pkg.recipe
+++ b/Brim/Brim.pkg.recipe
@@ -18,6 +18,15 @@
     <key>Process</key>
     <array>
         <dict>
+            <key>Processor</key>
+            <string>DeprecationWarning</string>
+            <key>Arguments</key>
+            <dict>
+                <key>warning_message</key>
+                <string>This recipe is deprecated and is no longer maintained by Zentral. It may stop working at any time and will not receive further updates. If you rely on it and would like to take over maintenance, we'd be glad to help hand it off — please open an issue at https://github.com/autopkg/zentral-recipes/issues to get in touch.</string>
+            </dict>
+        </dict>
+        <dict>
             <key>Arguments</key>
             <dict>
                 <key>info_path</key>

--- a/Chrome_Remote_Desktop/ChromeRemoteDesktop.download.recipe
+++ b/Chrome_Remote_Desktop/ChromeRemoteDesktop.download.recipe
@@ -19,6 +19,15 @@
     <array>
         <dict>
             <key>Processor</key>
+            <string>DeprecationWarning</string>
+            <key>Arguments</key>
+            <dict>
+                <key>warning_message</key>
+                <string>This recipe is deprecated and is no longer maintained by Zentral. It may stop working at any time and will not receive further updates. If you rely on it and would like to take over maintenance, we'd be glad to help hand it off — please open an issue at https://github.com/autopkg/zentral-recipes/issues to get in touch.</string>
+            </dict>
+        </dict>
+        <dict>
+            <key>Processor</key>
             <string>URLDownloader</string>
             <key>Arguments</key>
             <dict>

--- a/Chrome_Remote_Desktop/ChromeRemoteDesktop.munki.recipe
+++ b/Chrome_Remote_Desktop/ChromeRemoteDesktop.munki.recipe
@@ -48,6 +48,15 @@ Set the DERIVE_MIN_OS variable to a non-empty string to set the minimum_os_versi
     </dict>
     <key>Process</key>
     <array>
+        <dict>
+            <key>Processor</key>
+            <string>DeprecationWarning</string>
+            <key>Arguments</key>
+            <dict>
+                <key>warning_message</key>
+                <string>This recipe is deprecated and is no longer maintained by Zentral. It may stop working at any time and will not receive further updates. If you rely on it and would like to take over maintenance, we'd be glad to help hand it off — please open an issue at https://github.com/autopkg/zentral-recipes/issues to get in touch.</string>
+            </dict>
+        </dict>
         <!-- NOTE!
           Make sure we have the correct version, not accidentally the version of the pkg itself
         -->

--- a/Crescendo/Crescendo.download.recipe
+++ b/Crescendo/Crescendo.download.recipe
@@ -21,6 +21,15 @@
     <array>
         <dict>
             <key>Processor</key>
+            <string>DeprecationWarning</string>
+            <key>Arguments</key>
+            <dict>
+                <key>warning_message</key>
+                <string>This recipe is deprecated and is no longer maintained by Zentral. It may stop working at any time and will not receive further updates. If you rely on it and would like to take over maintenance, we'd be glad to help hand it off — please open an issue at https://github.com/autopkg/zentral-recipes/issues to get in touch.</string>
+            </dict>
+        </dict>
+        <dict>
+            <key>Processor</key>
             <string>GitHubReleasesInfoProvider</string>
             <key>Arguments</key>
             <dict>

--- a/Crescendo/Crescendo.pkg.recipe
+++ b/Crescendo/Crescendo.pkg.recipe
@@ -18,6 +18,15 @@
     <key>Process</key>
     <array>
         <dict>
+            <key>Processor</key>
+            <string>DeprecationWarning</string>
+            <key>Arguments</key>
+            <dict>
+                <key>warning_message</key>
+                <string>This recipe is deprecated and is no longer maintained by Zentral. It may stop working at any time and will not receive further updates. If you rely on it and would like to take over maintenance, we'd be glad to help hand it off — please open an issue at https://github.com/autopkg/zentral-recipes/issues to get in touch.</string>
+            </dict>
+        </dict>
+        <dict>
             <key>Arguments</key>
             <dict>
                 <key>info_path</key>

--- a/Cutter/Cutter.download.recipe
+++ b/Cutter/Cutter.download.recipe
@@ -28,6 +28,15 @@ Set INCLUDE_PRERELEASES to a non-empty string to download prereleases from GitHu
     <array>
         <dict>
             <key>Processor</key>
+            <string>DeprecationWarning</string>
+            <key>Arguments</key>
+            <dict>
+                <key>warning_message</key>
+                <string>This recipe is deprecated and is no longer maintained by Zentral. It may stop working at any time and will not receive further updates. If you rely on it and would like to take over maintenance, we'd be glad to help hand it off — please open an issue at https://github.com/autopkg/zentral-recipes/issues to get in touch.</string>
+            </dict>
+        </dict>
+        <dict>
+            <key>Processor</key>
             <string>GitHubReleasesInfoProvider</string>
             <key>Arguments</key>
             <dict>

--- a/Cutter/Cutter.install.recipe
+++ b/Cutter/Cutter.install.recipe
@@ -18,6 +18,15 @@
     <key>Process</key>
     <array>
         <dict>
+            <key>Processor</key>
+            <string>DeprecationWarning</string>
+            <key>Arguments</key>
+            <dict>
+                <key>warning_message</key>
+                <string>This recipe is deprecated and is no longer maintained by Zentral. It may stop working at any time and will not receive further updates. If you rely on it and would like to take over maintenance, we'd be glad to help hand it off — please open an issue at https://github.com/autopkg/zentral-recipes/issues to get in touch.</string>
+            </dict>
+        </dict>
+        <dict>
             <key>Arguments</key>
             <dict>
                 <key>dmg_path</key>

--- a/Cutter/Cutter.pkg.recipe
+++ b/Cutter/Cutter.pkg.recipe
@@ -19,6 +19,15 @@
     <array>
         <dict>
             <key>Processor</key>
+            <string>DeprecationWarning</string>
+            <key>Arguments</key>
+            <dict>
+                <key>warning_message</key>
+                <string>This recipe is deprecated and is no longer maintained by Zentral. It may stop working at any time and will not receive further updates. If you rely on it and would like to take over maintenance, we'd be glad to help hand it off — please open an issue at https://github.com/autopkg/zentral-recipes/issues to get in touch.</string>
+            </dict>
+        </dict>
+        <dict>
+            <key>Processor</key>
             <string>AppPkgCreator</string>
         </dict>
     </array>

--- a/Deckset/Deckset.download.recipe
+++ b/Deckset/Deckset.download.recipe
@@ -19,6 +19,15 @@
     <array>
         <dict>
             <key>Processor</key>
+            <string>DeprecationWarning</string>
+            <key>Arguments</key>
+            <dict>
+                <key>warning_message</key>
+                <string>This recipe is deprecated and is no longer maintained by Zentral. It may stop working at any time and will not receive further updates. If you rely on it and would like to take over maintenance, we'd be glad to help hand it off — please open an issue at https://github.com/autopkg/zentral-recipes/issues to get in touch.</string>
+            </dict>
+        </dict>
+        <dict>
+            <key>Processor</key>
             <string>URLDownloader</string>
             <key>Arguments</key>
             <dict>

--- a/Deckset/Deckset.install.recipe
+++ b/Deckset/Deckset.install.recipe
@@ -19,6 +19,15 @@
     <array>
         <dict>
             <key>Processor</key>
+            <string>DeprecationWarning</string>
+            <key>Arguments</key>
+            <dict>
+                <key>warning_message</key>
+                <string>This recipe is deprecated and is no longer maintained by Zentral. It may stop working at any time and will not receive further updates. If you rely on it and would like to take over maintenance, we'd be glad to help hand it off — please open an issue at https://github.com/autopkg/zentral-recipes/issues to get in touch.</string>
+            </dict>
+        </dict>
+        <dict>
+            <key>Processor</key>
             <string>InstallFromDMG</string>
             <key>Arguments</key>
             <dict>

--- a/Deckset/Deckset.munki.recipe
+++ b/Deckset/Deckset.munki.recipe
@@ -44,6 +44,15 @@
     <array>
         <dict>
             <key>Processor</key>
+            <string>DeprecationWarning</string>
+            <key>Arguments</key>
+            <dict>
+                <key>warning_message</key>
+                <string>This recipe is deprecated and is no longer maintained by Zentral. It may stop working at any time and will not receive further updates. If you rely on it and would like to take over maintenance, we'd be glad to help hand it off — please open an issue at https://github.com/autopkg/zentral-recipes/issues to get in touch.</string>
+            </dict>
+        </dict>
+        <dict>
+            <key>Processor</key>
             <string>MunkiImporter</string>
             <key>Arguments</key>
             <dict>

--- a/FileMonitor/FileMonitor.download.recipe
+++ b/FileMonitor/FileMonitor.download.recipe
@@ -22,6 +22,15 @@
     <key>Process</key>
     <array>
         <dict>
+            <key>Processor</key>
+            <string>DeprecationWarning</string>
+            <key>Arguments</key>
+            <dict>
+                <key>warning_message</key>
+                <string>This recipe is deprecated and is no longer maintained by Zentral. It may stop working at any time and will not receive further updates. If you rely on it and would like to take over maintenance, we'd be glad to help hand it off — please open an issue at https://github.com/autopkg/zentral-recipes/issues to get in touch.</string>
+            </dict>
+        </dict>
+        <dict>
           <key>Processor</key>
           <string>URLTextSearcher</string>
           <key>Arguments</key>

--- a/FileMonitor/FileMonitor.install.recipe
+++ b/FileMonitor/FileMonitor.install.recipe
@@ -16,6 +16,15 @@
     <array>
         <dict>
             <key>Processor</key>
+            <string>DeprecationWarning</string>
+            <key>Arguments</key>
+            <dict>
+                <key>warning_message</key>
+                <string>This recipe is deprecated and is no longer maintained by Zentral. It may stop working at any time and will not receive further updates. If you rely on it and would like to take over maintenance, we'd be glad to help hand it off — please open an issue at https://github.com/autopkg/zentral-recipes/issues to get in touch.</string>
+            </dict>
+        </dict>
+        <dict>
+            <key>Processor</key>
             <string>Installer</string>
             <key>Arguments</key>
             <dict>

--- a/FileMonitor/FileMonitor.munki.recipe
+++ b/FileMonitor/FileMonitor.munki.recipe
@@ -46,6 +46,15 @@
     <array>
         <dict>
             <key>Processor</key>
+            <string>DeprecationWarning</string>
+            <key>Arguments</key>
+            <dict>
+                <key>warning_message</key>
+                <string>This recipe is deprecated and is no longer maintained by Zentral. It may stop working at any time and will not receive further updates. If you rely on it and would like to take over maintenance, we'd be glad to help hand it off — please open an issue at https://github.com/autopkg/zentral-recipes/issues to get in touch.</string>
+            </dict>
+        </dict>
+        <dict>
+            <key>Processor</key>
             <string>MunkiImporter</string>
             <key>Arguments</key>
             <dict>

--- a/FileMonitor/FileMonitor.pkg.recipe
+++ b/FileMonitor/FileMonitor.pkg.recipe
@@ -18,6 +18,15 @@
     <key>Process</key>
     <array>
         <dict>
+            <key>Processor</key>
+            <string>DeprecationWarning</string>
+            <key>Arguments</key>
+            <dict>
+                <key>warning_message</key>
+                <string>This recipe is deprecated and is no longer maintained by Zentral. It may stop working at any time and will not receive further updates. If you rely on it and would like to take over maintenance, we'd be glad to help hand it off — please open an issue at https://github.com/autopkg/zentral-recipes/issues to get in touch.</string>
+            </dict>
+        </dict>
+        <dict>
           <key>Processor</key>
           <string>AppPkgCreator</string>
           <key>Arguments</key>

--- a/FileMonitor/FileMonitorDMG.munki.recipe
+++ b/FileMonitor/FileMonitorDMG.munki.recipe
@@ -43,6 +43,15 @@
     <key>Process</key>
     <array>
         <dict>
+            <key>Processor</key>
+            <string>DeprecationWarning</string>
+            <key>Arguments</key>
+            <dict>
+                <key>warning_message</key>
+                <string>This recipe is deprecated and is no longer maintained by Zentral. It may stop working at any time and will not receive further updates. If you rely on it and would like to take over maintenance, we'd be glad to help hand it off — please open an issue at https://github.com/autopkg/zentral-recipes/issues to get in touch.</string>
+            </dict>
+        </dict>
+        <dict>
             <key>Arguments</key>
             <dict>
                 <key>dmg_path</key>

--- a/JamfProSwitcher/JamfProSwitcher.download.recipe
+++ b/JamfProSwitcher/JamfProSwitcher.download.recipe
@@ -21,6 +21,15 @@
     <array>
         <dict>
             <key>Processor</key>
+            <string>DeprecationWarning</string>
+            <key>Arguments</key>
+            <dict>
+                <key>warning_message</key>
+                <string>This recipe is deprecated and is no longer maintained by Zentral. It may stop working at any time and will not receive further updates. If you rely on it and would like to take over maintenance, we'd be glad to help hand it off — please open an issue at https://github.com/autopkg/zentral-recipes/issues to get in touch.</string>
+            </dict>
+        </dict>
+        <dict>
+            <key>Processor</key>
             <string>GitHubReleasesInfoProvider</string>
             <key>Arguments</key>
             <dict>

--- a/JamfProSwitcher/JamfProSwitcher.install.recipe
+++ b/JamfProSwitcher/JamfProSwitcher.install.recipe
@@ -19,6 +19,15 @@
     <array>
         <dict>
             <key>Processor</key>
+            <string>DeprecationWarning</string>
+            <key>Arguments</key>
+            <dict>
+                <key>warning_message</key>
+                <string>This recipe is deprecated and is no longer maintained by Zentral. It may stop working at any time and will not receive further updates. If you rely on it and would like to take over maintenance, we'd be glad to help hand it off — please open an issue at https://github.com/autopkg/zentral-recipes/issues to get in touch.</string>
+            </dict>
+        </dict>
+        <dict>
+            <key>Processor</key>
             <string>InstallFromDMG</string>
 						<key>Arguments</key>
 						<dict>

--- a/JamfProSwitcher/JamfProSwitcher.munki.recipe
+++ b/JamfProSwitcher/JamfProSwitcher.munki.recipe
@@ -44,6 +44,15 @@
     <array>
         <dict>
             <key>Processor</key>
+            <string>DeprecationWarning</string>
+            <key>Arguments</key>
+            <dict>
+                <key>warning_message</key>
+                <string>This recipe is deprecated and is no longer maintained by Zentral. It may stop working at any time and will not receive further updates. If you rely on it and would like to take over maintenance, we'd be glad to help hand it off — please open an issue at https://github.com/autopkg/zentral-recipes/issues to get in touch.</string>
+            </dict>
+        </dict>
+        <dict>
+            <key>Processor</key>
             <string>MunkiImporter</string>
             <key>Arguments</key>
             <dict>

--- a/LanguageTool/LanguageToolDesktop.download.recipe
+++ b/LanguageTool/LanguageToolDesktop.download.recipe
@@ -21,6 +21,15 @@
     <array>
         <dict>
             <key>Processor</key>
+            <string>DeprecationWarning</string>
+            <key>Arguments</key>
+            <dict>
+                <key>warning_message</key>
+                <string>This recipe is deprecated and is no longer maintained by Zentral. It may stop working at any time and will not receive further updates. If you rely on it and would like to take over maintenance, we'd be glad to help hand it off — please open an issue at https://github.com/autopkg/zentral-recipes/issues to get in touch.</string>
+            </dict>
+        </dict>
+        <dict>
+            <key>Processor</key>
             <string>URLDownloader</string>
             <key>Arguments</key>
             <dict>

--- a/LanguageTool/LanguageToolDesktop.install.recipe
+++ b/LanguageTool/LanguageToolDesktop.install.recipe
@@ -16,6 +16,15 @@
     <array>
         <dict>
             <key>Processor</key>
+            <string>DeprecationWarning</string>
+            <key>Arguments</key>
+            <dict>
+                <key>warning_message</key>
+                <string>This recipe is deprecated and is no longer maintained by Zentral. It may stop working at any time and will not receive further updates. If you rely on it and would like to take over maintenance, we'd be glad to help hand it off — please open an issue at https://github.com/autopkg/zentral-recipes/issues to get in touch.</string>
+            </dict>
+        </dict>
+        <dict>
+            <key>Processor</key>
             <string>Installer</string>
             <key>Arguments</key>
             <dict>

--- a/LanguageTool/LanguageToolDesktop.munki.recipe
+++ b/LanguageTool/LanguageToolDesktop.munki.recipe
@@ -46,6 +46,15 @@
     <array>
         <dict>
             <key>Processor</key>
+            <string>DeprecationWarning</string>
+            <key>Arguments</key>
+            <dict>
+                <key>warning_message</key>
+                <string>This recipe is deprecated and is no longer maintained by Zentral. It may stop working at any time and will not receive further updates. If you rely on it and would like to take over maintenance, we'd be glad to help hand it off — please open an issue at https://github.com/autopkg/zentral-recipes/issues to get in touch.</string>
+            </dict>
+        </dict>
+        <dict>
+            <key>Processor</key>
             <string>MunkiImporter</string>
             <key>Arguments</key>
             <dict>

--- a/LanguageTool/LanguageToolDesktop.pkg.recipe
+++ b/LanguageTool/LanguageToolDesktop.pkg.recipe
@@ -18,6 +18,15 @@
     <key>Process</key>
     <array>
         <dict>
+            <key>Processor</key>
+            <string>DeprecationWarning</string>
+            <key>Arguments</key>
+            <dict>
+                <key>warning_message</key>
+                <string>This recipe is deprecated and is no longer maintained by Zentral. It may stop working at any time and will not receive further updates. If you rely on it and would like to take over maintenance, we'd be glad to help hand it off — please open an issue at https://github.com/autopkg/zentral-recipes/issues to get in touch.</string>
+            </dict>
+        </dict>
+        <dict>
             <key>Arguments</key>
             <dict>
                 <key>info_path</key>

--- a/Netiquette/Netiquette.download.recipe
+++ b/Netiquette/Netiquette.download.recipe
@@ -18,6 +18,15 @@
     <key>Process</key>
     <array>
         <dict>
+            <key>Processor</key>
+            <string>DeprecationWarning</string>
+            <key>Arguments</key>
+            <dict>
+                <key>warning_message</key>
+                <string>This recipe is deprecated and is no longer maintained by Zentral. It may stop working at any time and will not receive further updates. If you rely on it and would like to take over maintenance, we'd be glad to help hand it off — please open an issue at https://github.com/autopkg/zentral-recipes/issues to get in touch.</string>
+            </dict>
+        </dict>
+        <dict>
           <key>Processor</key>
           <string>GitHubReleasesInfoProvider</string>
             <key>Arguments</key>

--- a/Netiquette/Netiquette.install.recipe
+++ b/Netiquette/Netiquette.install.recipe
@@ -16,6 +16,15 @@
     <array>
         <dict>
             <key>Processor</key>
+            <string>DeprecationWarning</string>
+            <key>Arguments</key>
+            <dict>
+                <key>warning_message</key>
+                <string>This recipe is deprecated and is no longer maintained by Zentral. It may stop working at any time and will not receive further updates. If you rely on it and would like to take over maintenance, we'd be glad to help hand it off — please open an issue at https://github.com/autopkg/zentral-recipes/issues to get in touch.</string>
+            </dict>
+        </dict>
+        <dict>
+            <key>Processor</key>
             <string>Installer</string>
             <key>Arguments</key>
             <dict>

--- a/Netiquette/Netiquette.munki.recipe
+++ b/Netiquette/Netiquette.munki.recipe
@@ -46,6 +46,15 @@
     <array>
         <dict>
             <key>Processor</key>
+            <string>DeprecationWarning</string>
+            <key>Arguments</key>
+            <dict>
+                <key>warning_message</key>
+                <string>This recipe is deprecated and is no longer maintained by Zentral. It may stop working at any time and will not receive further updates. If you rely on it and would like to take over maintenance, we'd be glad to help hand it off — please open an issue at https://github.com/autopkg/zentral-recipes/issues to get in touch.</string>
+            </dict>
+        </dict>
+        <dict>
+            <key>Processor</key>
             <string>MunkiImporter</string>
             <key>Arguments</key>
             <dict>

--- a/Netiquette/Netiquette.pkg.recipe
+++ b/Netiquette/Netiquette.pkg.recipe
@@ -18,6 +18,15 @@
     <key>Process</key>
     <array>
         <dict>
+            <key>Processor</key>
+            <string>DeprecationWarning</string>
+            <key>Arguments</key>
+            <dict>
+                <key>warning_message</key>
+                <string>This recipe is deprecated and is no longer maintained by Zentral. It may stop working at any time and will not receive further updates. If you rely on it and would like to take over maintenance, we'd be glad to help hand it off — please open an issue at https://github.com/autopkg/zentral-recipes/issues to get in touch.</string>
+            </dict>
+        </dict>
+        <dict>
           <key>Processor</key>
           <string>AppPkgCreator</string>
           <key>Arguments</key>

--- a/Nova/Nova.download.recipe
+++ b/Nova/Nova.download.recipe
@@ -19,6 +19,15 @@
     <array>
         <dict>
             <key>Processor</key>
+            <string>DeprecationWarning</string>
+            <key>Arguments</key>
+            <dict>
+                <key>warning_message</key>
+                <string>This recipe is deprecated and is no longer maintained by Zentral. It may stop working at any time and will not receive further updates. If you rely on it and would like to take over maintenance, we'd be glad to help hand it off — please open an issue at https://github.com/autopkg/zentral-recipes/issues to get in touch.</string>
+            </dict>
+        </dict>
+        <dict>
+            <key>Processor</key>
             <string>URLDownloader</string>
             <key>Arguments</key>
             <dict>

--- a/Nova/Nova.install.recipe
+++ b/Nova/Nova.install.recipe
@@ -16,6 +16,15 @@
     <array>
         <dict>
             <key>Processor</key>
+            <string>DeprecationWarning</string>
+            <key>Arguments</key>
+            <dict>
+                <key>warning_message</key>
+                <string>This recipe is deprecated and is no longer maintained by Zentral. It may stop working at any time and will not receive further updates. If you rely on it and would like to take over maintenance, we'd be glad to help hand it off — please open an issue at https://github.com/autopkg/zentral-recipes/issues to get in touch.</string>
+            </dict>
+        </dict>
+        <dict>
+            <key>Processor</key>
             <string>DmgCreator</string>
             <key>Arguments</key>
             <dict>

--- a/Nova/Nova.munki.recipe
+++ b/Nova/Nova.munki.recipe
@@ -69,6 +69,15 @@ rm -f "/usr/local/bin/nova"
     <array>
         <dict>
             <key>Processor</key>
+            <string>DeprecationWarning</string>
+            <key>Arguments</key>
+            <dict>
+                <key>warning_message</key>
+                <string>This recipe is deprecated and is no longer maintained by Zentral. It may stop working at any time and will not receive further updates. If you rely on it and would like to take over maintenance, we'd be glad to help hand it off — please open an issue at https://github.com/autopkg/zentral-recipes/issues to get in touch.</string>
+            </dict>
+        </dict>
+        <dict>
+            <key>Processor</key>
             <string>DmgCreator</string>
             <key>Arguments</key>
             <dict>

--- a/Nova/Nova.pkg.recipe
+++ b/Nova/Nova.pkg.recipe
@@ -18,6 +18,15 @@
     <key>Process</key>
     <array>
         <dict>
+            <key>Processor</key>
+            <string>DeprecationWarning</string>
+            <key>Arguments</key>
+            <dict>
+                <key>warning_message</key>
+                <string>This recipe is deprecated and is no longer maintained by Zentral. It may stop working at any time and will not receive further updates. If you rely on it and would like to take over maintenance, we'd be glad to help hand it off — please open an issue at https://github.com/autopkg/zentral-recipes/issues to get in touch.</string>
+            </dict>
+        </dict>
+        <dict>
             <key>Arguments</key>
             <dict>
                 <key>info_path</key>

--- a/Oni/Oni.download.recipe
+++ b/Oni/Oni.download.recipe
@@ -19,6 +19,15 @@
     <array>
         <dict>
             <key>Processor</key>
+            <string>DeprecationWarning</string>
+            <key>Arguments</key>
+            <dict>
+                <key>warning_message</key>
+                <string>This recipe is deprecated and is no longer maintained by Zentral. It may stop working at any time and will not receive further updates. If you rely on it and would like to take over maintenance, we'd be glad to help hand it off — please open an issue at https://github.com/autopkg/zentral-recipes/issues to get in touch.</string>
+            </dict>
+        </dict>
+        <dict>
+            <key>Processor</key>
             <string>GitHubReleasesInfoProvider</string>
             <key>Arguments</key>
             <dict>

--- a/Oni/Oni.install.recipe
+++ b/Oni/Oni.install.recipe
@@ -19,6 +19,15 @@
     <array>
         <dict>
             <key>Processor</key>
+            <string>DeprecationWarning</string>
+            <key>Arguments</key>
+            <dict>
+                <key>warning_message</key>
+                <string>This recipe is deprecated and is no longer maintained by Zentral. It may stop working at any time and will not receive further updates. If you rely on it and would like to take over maintenance, we'd be glad to help hand it off — please open an issue at https://github.com/autopkg/zentral-recipes/issues to get in touch.</string>
+            </dict>
+        </dict>
+        <dict>
+            <key>Processor</key>
             <string>InstallFromDMG</string>
 						<key>Arguments</key>
 						<dict>

--- a/Oni/Oni.munki.recipe
+++ b/Oni/Oni.munki.recipe
@@ -44,6 +44,15 @@
     <array>
         <dict>
             <key>Processor</key>
+            <string>DeprecationWarning</string>
+            <key>Arguments</key>
+            <dict>
+                <key>warning_message</key>
+                <string>This recipe is deprecated and is no longer maintained by Zentral. It may stop working at any time and will not receive further updates. If you rely on it and would like to take over maintenance, we'd be glad to help hand it off — please open an issue at https://github.com/autopkg/zentral-recipes/issues to get in touch.</string>
+            </dict>
+        </dict>
+        <dict>
+            <key>Processor</key>
             <string>MunkiImporter</string>
             <key>Arguments</key>
             <dict>

--- a/Overkill/Overkill.download.recipe
+++ b/Overkill/Overkill.download.recipe
@@ -21,6 +21,15 @@
     <array>
         <dict>
             <key>Processor</key>
+            <string>DeprecationWarning</string>
+            <key>Arguments</key>
+            <dict>
+                <key>warning_message</key>
+                <string>This recipe is deprecated and is no longer maintained by Zentral. It may stop working at any time and will not receive further updates. If you rely on it and would like to take over maintenance, we'd be glad to help hand it off — please open an issue at https://github.com/autopkg/zentral-recipes/issues to get in touch.</string>
+            </dict>
+        </dict>
+        <dict>
+            <key>Processor</key>
             <string>GitHubReleasesInfoProvider</string>
             <key>Arguments</key>
             <dict>

--- a/Overkill/Overkill.install.recipe
+++ b/Overkill/Overkill.install.recipe
@@ -16,6 +16,15 @@
     <array>
         <dict>
             <key>Processor</key>
+            <string>DeprecationWarning</string>
+            <key>Arguments</key>
+            <dict>
+                <key>warning_message</key>
+                <string>This recipe is deprecated and is no longer maintained by Zentral. It may stop working at any time and will not receive further updates. If you rely on it and would like to take over maintenance, we'd be glad to help hand it off — please open an issue at https://github.com/autopkg/zentral-recipes/issues to get in touch.</string>
+            </dict>
+        </dict>
+        <dict>
+            <key>Processor</key>
             <string>Installer</string>
 						<key>Arguments</key>
 						<dict>

--- a/Overkill/Overkill.munki.recipe
+++ b/Overkill/Overkill.munki.recipe
@@ -42,6 +42,15 @@
     </dict>
     <key>Process</key>
     <array>
+        <dict>
+            <key>Processor</key>
+            <string>DeprecationWarning</string>
+            <key>Arguments</key>
+            <dict>
+                <key>warning_message</key>
+                <string>This recipe is deprecated and is no longer maintained by Zentral. It may stop working at any time and will not receive further updates. If you rely on it and would like to take over maintenance, we'd be glad to help hand it off — please open an issue at https://github.com/autopkg/zentral-recipes/issues to get in touch.</string>
+            </dict>
+        </dict>
 				<dict>
 					<key>Processor</key>
 					<string>DmgCreator</string>

--- a/Overkill/Overkill.pkg.recipe
+++ b/Overkill/Overkill.pkg.recipe
@@ -17,6 +17,15 @@
     <string>com.github.apfelwerk.download.Overkill</string>
     <key>Process</key>
     <array>
+        <dict>
+            <key>Processor</key>
+            <string>DeprecationWarning</string>
+            <key>Arguments</key>
+            <dict>
+                <key>warning_message</key>
+                <string>This recipe is deprecated and is no longer maintained by Zentral. It may stop working at any time and will not receive further updates. If you rely on it and would like to take over maintenance, we'd be glad to help hand it off — please open an issue at https://github.com/autopkg/zentral-recipes/issues to get in touch.</string>
+            </dict>
+        </dict>
 				<dict>
 					<key>Processor</key>
 					<string>AppPkgCreator</string>

--- a/ProcessMonitor/ProcessMonitor.download.recipe
+++ b/ProcessMonitor/ProcessMonitor.download.recipe
@@ -22,6 +22,15 @@
     <key>Process</key>
     <array>
         <dict>
+            <key>Processor</key>
+            <string>DeprecationWarning</string>
+            <key>Arguments</key>
+            <dict>
+                <key>warning_message</key>
+                <string>This recipe is deprecated and is no longer maintained by Zentral. It may stop working at any time and will not receive further updates. If you rely on it and would like to take over maintenance, we'd be glad to help hand it off — please open an issue at https://github.com/autopkg/zentral-recipes/issues to get in touch.</string>
+            </dict>
+        </dict>
+        <dict>
           <key>Processor</key>
           <string>URLTextSearcher</string>
           <key>Arguments</key>

--- a/ProcessMonitor/ProcessMonitor.install.recipe
+++ b/ProcessMonitor/ProcessMonitor.install.recipe
@@ -16,6 +16,15 @@
     <array>
         <dict>
             <key>Processor</key>
+            <string>DeprecationWarning</string>
+            <key>Arguments</key>
+            <dict>
+                <key>warning_message</key>
+                <string>This recipe is deprecated and is no longer maintained by Zentral. It may stop working at any time and will not receive further updates. If you rely on it and would like to take over maintenance, we'd be glad to help hand it off — please open an issue at https://github.com/autopkg/zentral-recipes/issues to get in touch.</string>
+            </dict>
+        </dict>
+        <dict>
+            <key>Processor</key>
             <string>Installer</string>
             <key>Arguments</key>
             <dict>

--- a/ProcessMonitor/ProcessMonitor.munki.recipe
+++ b/ProcessMonitor/ProcessMonitor.munki.recipe
@@ -46,6 +46,15 @@
     <array>
         <dict>
             <key>Processor</key>
+            <string>DeprecationWarning</string>
+            <key>Arguments</key>
+            <dict>
+                <key>warning_message</key>
+                <string>This recipe is deprecated and is no longer maintained by Zentral. It may stop working at any time and will not receive further updates. If you rely on it and would like to take over maintenance, we'd be glad to help hand it off — please open an issue at https://github.com/autopkg/zentral-recipes/issues to get in touch.</string>
+            </dict>
+        </dict>
+        <dict>
+            <key>Processor</key>
             <string>MunkiImporter</string>
             <key>Arguments</key>
             <dict>

--- a/ProcessMonitor/ProcessMonitor.pkg.recipe
+++ b/ProcessMonitor/ProcessMonitor.pkg.recipe
@@ -18,6 +18,15 @@
     <key>Process</key>
     <array>
         <dict>
+            <key>Processor</key>
+            <string>DeprecationWarning</string>
+            <key>Arguments</key>
+            <dict>
+                <key>warning_message</key>
+                <string>This recipe is deprecated and is no longer maintained by Zentral. It may stop working at any time and will not receive further updates. If you rely on it and would like to take over maintenance, we'd be glad to help hand it off — please open an issue at https://github.com/autopkg/zentral-recipes/issues to get in touch.</string>
+            </dict>
+        </dict>
+        <dict>
           <key>Processor</key>
           <string>AppPkgCreator</string>
           <key>Arguments</key>

--- a/ProcessMonitor/ProcessMonitorDMG.munki.recipe
+++ b/ProcessMonitor/ProcessMonitorDMG.munki.recipe
@@ -43,6 +43,15 @@
     <key>Process</key>
     <array>
         <dict>
+            <key>Processor</key>
+            <string>DeprecationWarning</string>
+            <key>Arguments</key>
+            <dict>
+                <key>warning_message</key>
+                <string>This recipe is deprecated and is no longer maintained by Zentral. It may stop working at any time and will not receive further updates. If you rely on it and would like to take over maintenance, we'd be glad to help hand it off — please open an issue at https://github.com/autopkg/zentral-recipes/issues to get in touch.</string>
+            </dict>
+        </dict>
+        <dict>
             <key>Arguments</key>
             <dict>
                 <key>dmg_path</key>

--- a/Proxyman/Proxyman.download.recipe
+++ b/Proxyman/Proxyman.download.recipe
@@ -21,6 +21,15 @@
     <array>
         <dict>
             <key>Processor</key>
+            <string>DeprecationWarning</string>
+            <key>Arguments</key>
+            <dict>
+                <key>warning_message</key>
+                <string>This recipe is deprecated and is no longer maintained by Zentral. It may stop working at any time and will not receive further updates. If you rely on it and would like to take over maintenance, we'd be glad to help hand it off — please open an issue at https://github.com/autopkg/zentral-recipes/issues to get in touch.</string>
+            </dict>
+        </dict>
+        <dict>
+            <key>Processor</key>
             <string>URLDownloader</string>
             <key>Arguments</key>
             <dict>

--- a/Proxyman/Proxyman.install.recipe
+++ b/Proxyman/Proxyman.install.recipe
@@ -16,6 +16,15 @@
     <array>
         <dict>
             <key>Processor</key>
+            <string>DeprecationWarning</string>
+            <key>Arguments</key>
+            <dict>
+                <key>warning_message</key>
+                <string>This recipe is deprecated and is no longer maintained by Zentral. It may stop working at any time and will not receive further updates. If you rely on it and would like to take over maintenance, we'd be glad to help hand it off — please open an issue at https://github.com/autopkg/zentral-recipes/issues to get in touch.</string>
+            </dict>
+        </dict>
+        <dict>
+            <key>Processor</key>
             <string>Installer</string>
             <key>Arguments</key>
             <dict>

--- a/Proxyman/Proxyman.munki.recipe
+++ b/Proxyman/Proxyman.munki.recipe
@@ -46,6 +46,15 @@
     <array>
         <dict>
             <key>Processor</key>
+            <string>DeprecationWarning</string>
+            <key>Arguments</key>
+            <dict>
+                <key>warning_message</key>
+                <string>This recipe is deprecated and is no longer maintained by Zentral. It may stop working at any time and will not receive further updates. If you rely on it and would like to take over maintenance, we'd be glad to help hand it off — please open an issue at https://github.com/autopkg/zentral-recipes/issues to get in touch.</string>
+            </dict>
+        </dict>
+        <dict>
+            <key>Processor</key>
             <string>MunkiImporter</string>
             <key>Arguments</key>
             <dict>

--- a/Proxyman/Proxyman.pkg.recipe
+++ b/Proxyman/Proxyman.pkg.recipe
@@ -18,6 +18,15 @@
     <key>Process</key>
     <array>
         <dict>
+            <key>Processor</key>
+            <string>DeprecationWarning</string>
+            <key>Arguments</key>
+            <dict>
+                <key>warning_message</key>
+                <string>This recipe is deprecated and is no longer maintained by Zentral. It may stop working at any time and will not receive further updates. If you rely on it and would like to take over maintenance, we'd be glad to help hand it off — please open an issue at https://github.com/autopkg/zentral-recipes/issues to get in touch.</string>
+            </dict>
+        </dict>
+        <dict>
             <key>Arguments</key>
             <dict>
                 <key>info_path</key>

--- a/README.md
+++ b/README.md
@@ -5,5 +5,26 @@ These are our autopkg-recipes.
 Some of them use parent recipes from the following repos:
 - _Privileges.munki_: https://github.com/autopkg/rtrouton-recipes/
 
-## Custom providers:
-- none so far
+
+
+## ⚠️ Deprecation notice
+
+Zentral is winding down this repository. Going forward we will **only maintain
+the recipes we use ourselves**:
+
+- `DrataAgent`
+- `osquery-extension`
+- `Privileges`
+- `santa`
+- `santa-lite`
+- `turbo`
+- `zentral_enrollpkgs`
+
+**All other recipes are deprecated and no longer maintained.** They now emit a
+`DeprecationWarning` when run. They may stop working at any time and will not
+receive further updates.
+
+If you rely on one of the deprecated recipes and would like to take over its
+maintenance, we'd be glad to help hand it off — please
+[open an issue](https://github.com/autopkg/zentral-recipes/issues) to get in
+touch.

--- a/Secretive/Secretive.download.recipe
+++ b/Secretive/Secretive.download.recipe
@@ -19,6 +19,15 @@
     <array>
         <dict>
             <key>Processor</key>
+            <string>DeprecationWarning</string>
+            <key>Arguments</key>
+            <dict>
+                <key>warning_message</key>
+                <string>This recipe is deprecated and is no longer maintained by Zentral. It may stop working at any time and will not receive further updates. If you rely on it and would like to take over maintenance, we'd be glad to help hand it off — please open an issue at https://github.com/autopkg/zentral-recipes/issues to get in touch.</string>
+            </dict>
+        </dict>
+        <dict>
+            <key>Processor</key>
             <string>GitHubReleasesInfoProvider</string>
             <key>Arguments</key>
             <dict>

--- a/Secretive/Secretive.munki.recipe
+++ b/Secretive/Secretive.munki.recipe
@@ -41,6 +41,15 @@
     <key>Process</key>
     <array>
         <dict>
+            <key>Processor</key>
+            <string>DeprecationWarning</string>
+            <key>Arguments</key>
+            <dict>
+                <key>warning_message</key>
+                <string>This recipe is deprecated and is no longer maintained by Zentral. It may stop working at any time and will not receive further updates. If you rely on it and would like to take over maintenance, we'd be glad to help hand it off — please open an issue at https://github.com/autopkg/zentral-recipes/issues to get in touch.</string>
+            </dict>
+        </dict>
+        <dict>
             <key>Arguments</key>
             <dict>
                 <key>dmg_megabytes</key>

--- a/Secretive/Secretive.pkg.recipe
+++ b/Secretive/Secretive.pkg.recipe
@@ -18,6 +18,15 @@
     <key>Process</key>
     <array>
         <dict>
+            <key>Processor</key>
+            <string>DeprecationWarning</string>
+            <key>Arguments</key>
+            <dict>
+                <key>warning_message</key>
+                <string>This recipe is deprecated and is no longer maintained by Zentral. It may stop working at any time and will not receive further updates. If you rely on it and would like to take over maintenance, we'd be glad to help hand it off — please open an issue at https://github.com/autopkg/zentral-recipes/issues to get in touch.</string>
+            </dict>
+        </dict>
+        <dict>
             <key>Arguments</key>
             <dict>
                 <key>info_path</key>

--- a/UXProtect/UXProtect.download.recipe
+++ b/UXProtect/UXProtect.download.recipe
@@ -22,6 +22,15 @@
     <key>Process</key>
     <array>
         <dict>
+            <key>Processor</key>
+            <string>DeprecationWarning</string>
+            <key>Arguments</key>
+            <dict>
+                <key>warning_message</key>
+                <string>This recipe is deprecated and is no longer maintained by Zentral. It may stop working at any time and will not receive further updates. If you rely on it and would like to take over maintenance, we'd be glad to help hand it off — please open an issue at https://github.com/autopkg/zentral-recipes/issues to get in touch.</string>
+            </dict>
+        </dict>
+        <dict>
           <key>Processor</key>
           <string>URLTextSearcher</string>
           <key>Arguments</key>

--- a/UXProtect/UXProtect.install.recipe
+++ b/UXProtect/UXProtect.install.recipe
@@ -16,6 +16,15 @@
     <array>
         <dict>
             <key>Processor</key>
+            <string>DeprecationWarning</string>
+            <key>Arguments</key>
+            <dict>
+                <key>warning_message</key>
+                <string>This recipe is deprecated and is no longer maintained by Zentral. It may stop working at any time and will not receive further updates. If you rely on it and would like to take over maintenance, we'd be glad to help hand it off — please open an issue at https://github.com/autopkg/zentral-recipes/issues to get in touch.</string>
+            </dict>
+        </dict>
+        <dict>
+            <key>Processor</key>
             <string>Installer</string>
             <key>Arguments</key>
             <dict>

--- a/UXProtect/UXProtect.munki.recipe
+++ b/UXProtect/UXProtect.munki.recipe
@@ -46,6 +46,15 @@
     <array>
         <dict>
             <key>Processor</key>
+            <string>DeprecationWarning</string>
+            <key>Arguments</key>
+            <dict>
+                <key>warning_message</key>
+                <string>This recipe is deprecated and is no longer maintained by Zentral. It may stop working at any time and will not receive further updates. If you rely on it and would like to take over maintenance, we'd be glad to help hand it off — please open an issue at https://github.com/autopkg/zentral-recipes/issues to get in touch.</string>
+            </dict>
+        </dict>
+        <dict>
+            <key>Processor</key>
             <string>MunkiImporter</string>
             <key>Arguments</key>
             <dict>

--- a/UXProtect/UXProtect.pkg.recipe
+++ b/UXProtect/UXProtect.pkg.recipe
@@ -18,6 +18,15 @@
     <key>Process</key>
     <array>
         <dict>
+            <key>Processor</key>
+            <string>DeprecationWarning</string>
+            <key>Arguments</key>
+            <dict>
+                <key>warning_message</key>
+                <string>This recipe is deprecated and is no longer maintained by Zentral. It may stop working at any time and will not receive further updates. If you rely on it and would like to take over maintenance, we'd be glad to help hand it off — please open an issue at https://github.com/autopkg/zentral-recipes/issues to get in touch.</string>
+            </dict>
+        </dict>
+        <dict>
           <key>Processor</key>
           <string>AppPkgCreator</string>
           <key>Arguments</key>

--- a/YubiKey_Manager/YubiKey_Manager.install.recipe
+++ b/YubiKey_Manager/YubiKey_Manager.install.recipe
@@ -16,6 +16,15 @@
     <array>
         <dict>
             <key>Processor</key>
+            <string>DeprecationWarning</string>
+            <key>Arguments</key>
+            <dict>
+                <key>warning_message</key>
+                <string>Yubico announced the End of Life of YubiKey Manager GUI on February 19, 2025, in line with Yubico’s End-of-Life policy (see https://www.yubico.com/support/download/yubikey-manager). YubiKey Manager GUI will reach its End of Life on February 19, 2026 (see https://www.yubico.com/support/terms-conditions/yubico-end-of-life-policy/eol-products). Yubico Authenticator is recommended as an alternative; a replacement recipe is available at com.github.Lotusshaney.download.YubicoAuthenticator.</string>
+            </dict>
+        </dict>
+        <dict>
+            <key>Processor</key>
             <string>Installer</string>
             <key>Arguments</key>
             <dict>

--- a/YubiKey_Manager/YubiKey_Manager.munki.recipe
+++ b/YubiKey_Manager/YubiKey_Manager.munki.recipe
@@ -46,6 +46,15 @@
     <array>
         <dict>
             <key>Processor</key>
+            <string>DeprecationWarning</string>
+            <key>Arguments</key>
+            <dict>
+                <key>warning_message</key>
+                <string>Yubico announced the End of Life of YubiKey Manager GUI on February 19, 2025, in line with Yubico’s End-of-Life policy (see https://www.yubico.com/support/download/yubikey-manager). YubiKey Manager GUI will reach its End of Life on February 19, 2026 (see https://www.yubico.com/support/terms-conditions/yubico-end-of-life-policy/eol-products). Yubico Authenticator is recommended as an alternative; a replacement recipe is available at com.github.Lotusshaney.download.YubicoAuthenticator.</string>
+            </dict>
+        </dict>
+        <dict>
+            <key>Processor</key>
             <string>MunkiInstallsItemsCreator</string>
             <key>Arguments</key>
             <dict>

--- a/act/act.download.recipe
+++ b/act/act.download.recipe
@@ -17,6 +17,15 @@
         <string>1.0.0</string>
         <key>Process</key>
         <array>
+                <dict>
+                        <key>Processor</key>
+                        <string>DeprecationWarning</string>
+                        <key>Arguments</key>
+                        <dict>
+                                <key>warning_message</key>
+                                <string>This recipe is deprecated and is no longer maintained by Zentral. It may stop working at any time and will not receive further updates. If you rely on it and would like to take over maintenance, we'd be glad to help hand it off — please open an issue at https://github.com/autopkg/zentral-recipes/issues to get in touch.</string>
+                        </dict>
+                </dict>
             <dict>
                 <key>Processor</key>
                 <string>GitHubReleasesInfoProvider</string>

--- a/act/act.install.recipe
+++ b/act/act.install.recipe
@@ -19,6 +19,15 @@
     <array>
         <dict>
             <key>Processor</key>
+            <string>DeprecationWarning</string>
+            <key>Arguments</key>
+            <dict>
+                <key>warning_message</key>
+                <string>This recipe is deprecated and is no longer maintained by Zentral. It may stop working at any time and will not receive further updates. If you rely on it and would like to take over maintenance, we'd be glad to help hand it off — please open an issue at https://github.com/autopkg/zentral-recipes/issues to get in touch.</string>
+            </dict>
+        </dict>
+        <dict>
+            <key>Processor</key>
             <string>Installer</string>
         </dict>
     </array>

--- a/act/act.munki.recipe
+++ b/act/act.munki.recipe
@@ -46,6 +46,15 @@
     <array>
         <dict>
             <key>Processor</key>
+            <string>DeprecationWarning</string>
+            <key>Arguments</key>
+            <dict>
+                <key>warning_message</key>
+                <string>This recipe is deprecated and is no longer maintained by Zentral. It may stop working at any time and will not receive further updates. If you rely on it and would like to take over maintenance, we'd be glad to help hand it off — please open an issue at https://github.com/autopkg/zentral-recipes/issues to get in touch.</string>
+            </dict>
+        </dict>
+        <dict>
+            <key>Processor</key>
             <string>MunkiImporter</string>
             <key>Arguments</key>
             <dict>

--- a/act/act.pkg.recipe
+++ b/act/act.pkg.recipe
@@ -21,6 +21,15 @@
         <string>com.github.zentralpro.download.act</string>
         <key>Process</key>
         <array>
+                <dict>
+                        <key>Processor</key>
+                        <string>DeprecationWarning</string>
+                        <key>Arguments</key>
+                        <dict>
+                                <key>warning_message</key>
+                                <string>This recipe is deprecated and is no longer maintained by Zentral. It may stop working at any time and will not receive further updates. If you rely on it and would like to take over maintenance, we'd be glad to help hand it off — please open an issue at https://github.com/autopkg/zentral-recipes/issues to get in touch.</string>
+                        </dict>
+                </dict>
             <dict>
                 <key>Processor</key>
                 <string>PkgRootCreator</string>

--- a/cue/cue.download.recipe
+++ b/cue/cue.download.recipe
@@ -17,6 +17,15 @@
         <string>1.0.0</string>
         <key>Process</key>
         <array>
+                <dict>
+                        <key>Processor</key>
+                        <string>DeprecationWarning</string>
+                        <key>Arguments</key>
+                        <dict>
+                                <key>warning_message</key>
+                                <string>This recipe is deprecated and is no longer maintained by Zentral. It may stop working at any time and will not receive further updates. If you rely on it and would like to take over maintenance, we'd be glad to help hand it off — please open an issue at https://github.com/autopkg/zentral-recipes/issues to get in touch.</string>
+                        </dict>
+                </dict>
             <dict>
                 <key>Processor</key>
                 <string>GitHubReleasesInfoProvider</string>

--- a/cue/cue.install.recipe
+++ b/cue/cue.install.recipe
@@ -19,6 +19,15 @@
     <array>
         <dict>
             <key>Processor</key>
+            <string>DeprecationWarning</string>
+            <key>Arguments</key>
+            <dict>
+                <key>warning_message</key>
+                <string>This recipe is deprecated and is no longer maintained by Zentral. It may stop working at any time and will not receive further updates. If you rely on it and would like to take over maintenance, we'd be glad to help hand it off — please open an issue at https://github.com/autopkg/zentral-recipes/issues to get in touch.</string>
+            </dict>
+        </dict>
+        <dict>
+            <key>Processor</key>
             <string>Installer</string>
         </dict>
     </array>

--- a/cue/cue.munki.recipe
+++ b/cue/cue.munki.recipe
@@ -46,6 +46,15 @@
     <array>
         <dict>
             <key>Processor</key>
+            <string>DeprecationWarning</string>
+            <key>Arguments</key>
+            <dict>
+                <key>warning_message</key>
+                <string>This recipe is deprecated and is no longer maintained by Zentral. It may stop working at any time and will not receive further updates. If you rely on it and would like to take over maintenance, we'd be glad to help hand it off — please open an issue at https://github.com/autopkg/zentral-recipes/issues to get in touch.</string>
+            </dict>
+        </dict>
+        <dict>
+            <key>Processor</key>
             <string>MunkiImporter</string>
             <key>Arguments</key>
             <dict>

--- a/cue/cue.pkg.recipe
+++ b/cue/cue.pkg.recipe
@@ -21,6 +21,15 @@
         <string>com.github.zentralpro.download.cue</string>
         <key>Process</key>
         <array>
+                <dict>
+                        <key>Processor</key>
+                        <string>DeprecationWarning</string>
+                        <key>Arguments</key>
+                        <dict>
+                                <key>warning_message</key>
+                                <string>This recipe is deprecated and is no longer maintained by Zentral. It may stop working at any time and will not receive further updates. If you rely on it and would like to take over maintenance, we'd be glad to help hand it off — please open an issue at https://github.com/autopkg/zentral-recipes/issues to get in touch.</string>
+                        </dict>
+                </dict>
             <dict>
                 <key>Processor</key>
                 <string>PkgRootCreator</string>

--- a/dog/dog.download.recipe
+++ b/dog/dog.download.recipe
@@ -17,6 +17,15 @@
         <string>1.0.0</string>
         <key>Process</key>
         <array>
+                <dict>
+                        <key>Processor</key>
+                        <string>DeprecationWarning</string>
+                        <key>Arguments</key>
+                        <dict>
+                                <key>warning_message</key>
+                                <string>This recipe is deprecated and is no longer maintained by Zentral. It may stop working at any time and will not receive further updates. If you rely on it and would like to take over maintenance, we'd be glad to help hand it off — please open an issue at https://github.com/autopkg/zentral-recipes/issues to get in touch.</string>
+                        </dict>
+                </dict>
             <dict>
                 <key>Processor</key>
                 <string>GitHubReleasesInfoProvider</string>

--- a/dog/dog.install.recipe
+++ b/dog/dog.install.recipe
@@ -19,6 +19,15 @@
     <array>
         <dict>
             <key>Processor</key>
+            <string>DeprecationWarning</string>
+            <key>Arguments</key>
+            <dict>
+                <key>warning_message</key>
+                <string>This recipe is deprecated and is no longer maintained by Zentral. It may stop working at any time and will not receive further updates. If you rely on it and would like to take over maintenance, we'd be glad to help hand it off — please open an issue at https://github.com/autopkg/zentral-recipes/issues to get in touch.</string>
+            </dict>
+        </dict>
+        <dict>
+            <key>Processor</key>
             <string>Installer</string>
         </dict>
     </array>

--- a/dog/dog.munki.recipe
+++ b/dog/dog.munki.recipe
@@ -46,6 +46,15 @@
     <array>
         <dict>
             <key>Processor</key>
+            <string>DeprecationWarning</string>
+            <key>Arguments</key>
+            <dict>
+                <key>warning_message</key>
+                <string>This recipe is deprecated and is no longer maintained by Zentral. It may stop working at any time and will not receive further updates. If you rely on it and would like to take over maintenance, we'd be glad to help hand it off — please open an issue at https://github.com/autopkg/zentral-recipes/issues to get in touch.</string>
+            </dict>
+        </dict>
+        <dict>
+            <key>Processor</key>
             <string>MunkiImporter</string>
             <key>Arguments</key>
             <dict>

--- a/dog/dog.pkg.recipe
+++ b/dog/dog.pkg.recipe
@@ -21,6 +21,15 @@
         <string>com.github.zentralpro.download.dog</string>
         <key>Process</key>
         <array>
+                <dict>
+                        <key>Processor</key>
+                        <string>DeprecationWarning</string>
+                        <key>Arguments</key>
+                        <dict>
+                                <key>warning_message</key>
+                                <string>This recipe is deprecated and is no longer maintained by Zentral. It may stop working at any time and will not receive further updates. If you rely on it and would like to take over maintenance, we'd be glad to help hand it off — please open an issue at https://github.com/autopkg/zentral-recipes/issues to get in touch.</string>
+                        </dict>
+                </dict>
             <dict>
                 <key>Processor</key>
                 <string>PkgRootCreator</string>

--- a/eapolcfg/eapolcfg.download.recipe
+++ b/eapolcfg/eapolcfg.download.recipe
@@ -20,6 +20,15 @@
     <key>Process</key>
     <array>
         <dict>
+            <key>Processor</key>
+            <string>DeprecationWarning</string>
+            <key>Arguments</key>
+            <dict>
+                <key>warning_message</key>
+                <string>This recipe is deprecated and is no longer maintained by Zentral. It may stop working at any time and will not receive further updates. If you rely on it and would like to take over maintenance, we'd be glad to help hand it off — please open an issue at https://github.com/autopkg/zentral-recipes/issues to get in touch.</string>
+            </dict>
+        </dict>
+        <dict>
           <key>Processor</key>
           <string>URLTextSearcher</string>
           <key>Arguments</key>

--- a/eapolcfg/eapolcfg.install.recipe
+++ b/eapolcfg/eapolcfg.install.recipe
@@ -19,6 +19,15 @@
     <array>
         <dict>
             <key>Processor</key>
+            <string>DeprecationWarning</string>
+            <key>Arguments</key>
+            <dict>
+                <key>warning_message</key>
+                <string>This recipe is deprecated and is no longer maintained by Zentral. It may stop working at any time and will not receive further updates. If you rely on it and would like to take over maintenance, we'd be glad to help hand it off — please open an issue at https://github.com/autopkg/zentral-recipes/issues to get in touch.</string>
+            </dict>
+        </dict>
+        <dict>
+            <key>Processor</key>
             <string>Installer</string>
         </dict>
     </array>

--- a/eapolcfg/eapolcfg.munki.recipe
+++ b/eapolcfg/eapolcfg.munki.recipe
@@ -46,6 +46,15 @@
     <array>
         <dict>
             <key>Processor</key>
+            <string>DeprecationWarning</string>
+            <key>Arguments</key>
+            <dict>
+                <key>warning_message</key>
+                <string>This recipe is deprecated and is no longer maintained by Zentral. It may stop working at any time and will not receive further updates. If you rely on it and would like to take over maintenance, we'd be glad to help hand it off — please open an issue at https://github.com/autopkg/zentral-recipes/issues to get in touch.</string>
+            </dict>
+        </dict>
+        <dict>
+            <key>Processor</key>
             <string>MunkiImporter</string>
             <key>Arguments</key>
             <dict>

--- a/eapolcfg/eapolcfg.pkg.recipe
+++ b/eapolcfg/eapolcfg.pkg.recipe
@@ -21,6 +21,15 @@
         <string>com.github.zentralpro.download.eapolcfg</string>
         <key>Process</key>
         <array>
+                <dict>
+                        <key>Processor</key>
+                        <string>DeprecationWarning</string>
+                        <key>Arguments</key>
+                        <dict>
+                                <key>warning_message</key>
+                                <string>This recipe is deprecated and is no longer maintained by Zentral. It may stop working at any time and will not receive further updates. If you rely on it and would like to take over maintenance, we'd be glad to help hand it off — please open an issue at https://github.com/autopkg/zentral-recipes/issues to get in touch.</string>
+                        </dict>
+                </dict>
             <dict>
                 <key>Processor</key>
                 <string>PkgRootCreator</string>

--- a/exa/exa.download.recipe
+++ b/exa/exa.download.recipe
@@ -17,6 +17,15 @@
         <string>1.0.0</string>
         <key>Process</key>
         <array>
+                <dict>
+                        <key>Processor</key>
+                        <string>DeprecationWarning</string>
+                        <key>Arguments</key>
+                        <dict>
+                                <key>warning_message</key>
+                                <string>This recipe is deprecated and is no longer maintained by Zentral. It may stop working at any time and will not receive further updates. If you rely on it and would like to take over maintenance, we'd be glad to help hand it off — please open an issue at https://github.com/autopkg/zentral-recipes/issues to get in touch.</string>
+                        </dict>
+                </dict>
             <dict>
                 <key>Processor</key>
                 <string>GitHubReleasesInfoProvider</string>

--- a/exa/exa.install.recipe
+++ b/exa/exa.install.recipe
@@ -19,6 +19,15 @@
     <array>
         <dict>
             <key>Processor</key>
+            <string>DeprecationWarning</string>
+            <key>Arguments</key>
+            <dict>
+                <key>warning_message</key>
+                <string>This recipe is deprecated and is no longer maintained by Zentral. It may stop working at any time and will not receive further updates. If you rely on it and would like to take over maintenance, we'd be glad to help hand it off — please open an issue at https://github.com/autopkg/zentral-recipes/issues to get in touch.</string>
+            </dict>
+        </dict>
+        <dict>
+            <key>Processor</key>
             <string>Installer</string>
         </dict>
     </array>

--- a/exa/exa.munki.recipe
+++ b/exa/exa.munki.recipe
@@ -45,6 +45,15 @@
         </dict>
         <key>Process</key>
         <array>
+                <dict>
+                        <key>Processor</key>
+                        <string>DeprecationWarning</string>
+                        <key>Arguments</key>
+                        <dict>
+                                <key>warning_message</key>
+                                <string>This recipe is deprecated and is no longer maintained by Zentral. It may stop working at any time and will not receive further updates. If you rely on it and would like to take over maintenance, we'd be glad to help hand it off — please open an issue at https://github.com/autopkg/zentral-recipes/issues to get in touch.</string>
+                        </dict>
+                </dict>
             <dict>
                 <key>Processor</key>
                 <string>MunkiImporter</string>

--- a/exa/exa.pkg.recipe
+++ b/exa/exa.pkg.recipe
@@ -21,6 +21,15 @@
         <string>com.github.zentralpro.download.exa</string>
         <key>Process</key>
         <array>
+                <dict>
+                        <key>Processor</key>
+                        <string>DeprecationWarning</string>
+                        <key>Arguments</key>
+                        <dict>
+                                <key>warning_message</key>
+                                <string>This recipe is deprecated and is no longer maintained by Zentral. It may stop working at any time and will not receive further updates. If you rely on it and would like to take over maintenance, we'd be glad to help hand it off — please open an issue at https://github.com/autopkg/zentral-recipes/issues to get in touch.</string>
+                        </dict>
+                </dict>
             <dict>
                 <key>Processor</key>
                 <string>PkgRootCreator</string>

--- a/iTaskX/iTaskX.download.recipe
+++ b/iTaskX/iTaskX.download.recipe
@@ -18,6 +18,15 @@
     <key>Process</key>
     <array>
         <dict>
+            <key>Processor</key>
+            <string>DeprecationWarning</string>
+            <key>Arguments</key>
+            <dict>
+                <key>warning_message</key>
+                <string>This recipe is deprecated and is no longer maintained by Zentral. It may stop working at any time and will not receive further updates. If you rely on it and would like to take over maintenance, we'd be glad to help hand it off — please open an issue at https://github.com/autopkg/zentral-recipes/issues to get in touch.</string>
+            </dict>
+        </dict>
+        <dict>
 						<key>Processor</key>
             <string>URLDownloader</string>
             <key>Arguments</key>

--- a/iTaskX/iTaskX.install.recipe
+++ b/iTaskX/iTaskX.install.recipe
@@ -19,6 +19,15 @@
     <array>
         <dict>
             <key>Processor</key>
+            <string>DeprecationWarning</string>
+            <key>Arguments</key>
+            <dict>
+                <key>warning_message</key>
+                <string>This recipe is deprecated and is no longer maintained by Zentral. It may stop working at any time and will not receive further updates. If you rely on it and would like to take over maintenance, we'd be glad to help hand it off — please open an issue at https://github.com/autopkg/zentral-recipes/issues to get in touch.</string>
+            </dict>
+        </dict>
+        <dict>
+            <key>Processor</key>
             <string>InstallFromDMG</string>
             <key>Arguments</key>
             <dict>

--- a/iTaskX/iTaskX.munki.recipe
+++ b/iTaskX/iTaskX.munki.recipe
@@ -45,6 +45,15 @@
     <array>
         <dict>
             <key>Processor</key>
+            <string>DeprecationWarning</string>
+            <key>Arguments</key>
+            <dict>
+                <key>warning_message</key>
+                <string>This recipe is deprecated and is no longer maintained by Zentral. It may stop working at any time and will not receive further updates. If you rely on it and would like to take over maintenance, we'd be glad to help hand it off — please open an issue at https://github.com/autopkg/zentral-recipes/issues to get in touch.</string>
+            </dict>
+        </dict>
+        <dict>
+            <key>Processor</key>
             <string>MunkiImporter</string>
             <key>Arguments</key>
             <dict>

--- a/miniserve/miniserve.download.recipe
+++ b/miniserve/miniserve.download.recipe
@@ -17,6 +17,15 @@
         <string>1.0.0</string>
         <key>Process</key>
         <array>
+                <dict>
+                        <key>Processor</key>
+                        <string>DeprecationWarning</string>
+                        <key>Arguments</key>
+                        <dict>
+                                <key>warning_message</key>
+                                <string>This recipe is deprecated and is no longer maintained by Zentral. It may stop working at any time and will not receive further updates. If you rely on it and would like to take over maintenance, we'd be glad to help hand it off — please open an issue at https://github.com/autopkg/zentral-recipes/issues to get in touch.</string>
+                        </dict>
+                </dict>
             <dict>
                 <key>Processor</key>
                 <string>GitHubReleasesInfoProvider</string>

--- a/miniserve/miniserve.install.recipe
+++ b/miniserve/miniserve.install.recipe
@@ -19,6 +19,15 @@
     <array>
         <dict>
             <key>Processor</key>
+            <string>DeprecationWarning</string>
+            <key>Arguments</key>
+            <dict>
+                <key>warning_message</key>
+                <string>This recipe is deprecated and is no longer maintained by Zentral. It may stop working at any time and will not receive further updates. If you rely on it and would like to take over maintenance, we'd be glad to help hand it off — please open an issue at https://github.com/autopkg/zentral-recipes/issues to get in touch.</string>
+            </dict>
+        </dict>
+        <dict>
+            <key>Processor</key>
             <string>Installer</string>
         </dict>
     </array>

--- a/miniserve/miniserve.munki.recipe
+++ b/miniserve/miniserve.munki.recipe
@@ -46,6 +46,15 @@
     <array>
         <dict>
             <key>Processor</key>
+            <string>DeprecationWarning</string>
+            <key>Arguments</key>
+            <dict>
+                <key>warning_message</key>
+                <string>This recipe is deprecated and is no longer maintained by Zentral. It may stop working at any time and will not receive further updates. If you rely on it and would like to take over maintenance, we'd be glad to help hand it off — please open an issue at https://github.com/autopkg/zentral-recipes/issues to get in touch.</string>
+            </dict>
+        </dict>
+        <dict>
+            <key>Processor</key>
             <string>MunkiImporter</string>
             <key>Arguments</key>
             <dict>

--- a/miniserve/miniserve.pkg.recipe
+++ b/miniserve/miniserve.pkg.recipe
@@ -21,6 +21,15 @@
         <string>com.github.zentralpro.download.miniserve</string>
         <key>Process</key>
         <array>
+                <dict>
+                        <key>Processor</key>
+                        <string>DeprecationWarning</string>
+                        <key>Arguments</key>
+                        <dict>
+                                <key>warning_message</key>
+                                <string>This recipe is deprecated and is no longer maintained by Zentral. It may stop working at any time and will not receive further updates. If you rely on it and would like to take over maintenance, we'd be glad to help hand it off — please open an issue at https://github.com/autopkg/zentral-recipes/issues to get in touch.</string>
+                        </dict>
+                </dict>
             <dict>
                 <key>Processor</key>
                 <string>PkgRootCreator</string>

--- a/mist/mist.download.recipe
+++ b/mist/mist.download.recipe
@@ -17,6 +17,15 @@
         <string>1.0.0</string>
         <key>Process</key>
         <array>
+                <dict>
+                        <key>Processor</key>
+                        <string>DeprecationWarning</string>
+                        <key>Arguments</key>
+                        <dict>
+                                <key>warning_message</key>
+                                <string>This recipe is deprecated and is no longer maintained by Zentral. It may stop working at any time and will not receive further updates. If you rely on it and would like to take over maintenance, we'd be glad to help hand it off — please open an issue at https://github.com/autopkg/zentral-recipes/issues to get in touch.</string>
+                        </dict>
+                </dict>
             <dict>
                 <key>Processor</key>
                 <string>GitHubReleasesInfoProvider</string>

--- a/mist/mist.install.recipe
+++ b/mist/mist.install.recipe
@@ -19,6 +19,15 @@
     <array>
         <dict>
             <key>Processor</key>
+            <string>DeprecationWarning</string>
+            <key>Arguments</key>
+            <dict>
+                <key>warning_message</key>
+                <string>This recipe is deprecated and is no longer maintained by Zentral. It may stop working at any time and will not receive further updates. If you rely on it and would like to take over maintenance, we'd be glad to help hand it off — please open an issue at https://github.com/autopkg/zentral-recipes/issues to get in touch.</string>
+            </dict>
+        </dict>
+        <dict>
+            <key>Processor</key>
             <string>Installer</string>
             <key>Arguments</key>
             <dict>

--- a/mist/mist.munki.recipe
+++ b/mist/mist.munki.recipe
@@ -53,6 +53,15 @@ Set the DERIVE_MIN_OS variable to a non-empty string to set the minimum_os_versi
     <key>Process</key>
     <array>
         <dict>
+            <key>Processor</key>
+            <string>DeprecationWarning</string>
+            <key>Arguments</key>
+            <dict>
+                <key>warning_message</key>
+                <string>This recipe is deprecated and is no longer maintained by Zentral. It may stop working at any time and will not receive further updates. If you rely on it and would like to take over maintenance, we'd be glad to help hand it off — please open an issue at https://github.com/autopkg/zentral-recipes/issues to get in touch.</string>
+            </dict>
+        </dict>
+        <dict>
             <key>Arguments</key>
             <dict>
                 <key>destination_path</key>

--- a/swiftDialog/swiftDialog.download.recipe
+++ b/swiftDialog/swiftDialog.download.recipe
@@ -17,6 +17,15 @@
         <string>1.0.0</string>
         <key>Process</key>
         <array>
+                <dict>
+                        <key>Processor</key>
+                        <string>DeprecationWarning</string>
+                        <key>Arguments</key>
+                        <dict>
+                                <key>warning_message</key>
+                                <string>This recipe is deprecated and is no longer maintained by Zentral. It may stop working at any time and will not receive further updates. If you rely on it and would like to take over maintenance, we'd be glad to help hand it off — please open an issue at https://github.com/autopkg/zentral-recipes/issues to get in touch.</string>
+                        </dict>
+                </dict>
             <dict>
                 <key>Processor</key>
                 <string>GitHubReleasesInfoProvider</string>

--- a/swiftDialog/swiftDialog.install.recipe
+++ b/swiftDialog/swiftDialog.install.recipe
@@ -19,6 +19,15 @@
     <array>
         <dict>
             <key>Processor</key>
+            <string>DeprecationWarning</string>
+            <key>Arguments</key>
+            <dict>
+                <key>warning_message</key>
+                <string>This recipe is deprecated and is no longer maintained by Zentral. It may stop working at any time and will not receive further updates. If you rely on it and would like to take over maintenance, we'd be glad to help hand it off — please open an issue at https://github.com/autopkg/zentral-recipes/issues to get in touch.</string>
+            </dict>
+        </dict>
+        <dict>
+            <key>Processor</key>
             <string>Installer</string>
             <key>Arguments</key>
             <dict>

--- a/swiftDialog/swiftDialog.jamf.recipe
+++ b/swiftDialog/swiftDialog.jamf.recipe
@@ -37,6 +37,15 @@
         </dict>
         <key>Process</key>
         <array>
+                <dict>
+                        <key>Processor</key>
+                        <string>DeprecationWarning</string>
+                        <key>Arguments</key>
+                        <dict>
+                                <key>warning_message</key>
+                                <string>This recipe is deprecated and is no longer maintained by Zentral. It may stop working at any time and will not receive further updates. If you rely on it and would like to take over maintenance, we'd be glad to help hand it off — please open an issue at https://github.com/autopkg/zentral-recipes/issues to get in touch.</string>
+                        </dict>
+                </dict>
             <dict>
                 <key>Arguments</key>
                 <dict>

--- a/swiftDialog/swiftDialog.munki.recipe
+++ b/swiftDialog/swiftDialog.munki.recipe
@@ -45,6 +45,15 @@
         </dict>
         <key>Process</key>
         <array>
+                <dict>
+                        <key>Processor</key>
+                        <string>DeprecationWarning</string>
+                        <key>Arguments</key>
+                        <dict>
+                                <key>warning_message</key>
+                                <string>This recipe is deprecated and is no longer maintained by Zentral. It may stop working at any time and will not receive further updates. If you rely on it and would like to take over maintenance, we'd be glad to help hand it off — please open an issue at https://github.com/autopkg/zentral-recipes/issues to get in touch.</string>
+                        </dict>
+                </dict>
             <dict>
                 <key>Processor</key>
                 <string>MunkiImporter</string>

--- a/tailwindcss/tailwindcss-cli.download.recipe
+++ b/tailwindcss/tailwindcss-cli.download.recipe
@@ -17,6 +17,15 @@
         <string>1.0.0</string>
         <key>Process</key>
         <array>
+                <dict>
+                        <key>Processor</key>
+                        <string>DeprecationWarning</string>
+                        <key>Arguments</key>
+                        <dict>
+                                <key>warning_message</key>
+                                <string>This recipe is deprecated and is no longer maintained by Zentral. It may stop working at any time and will not receive further updates. If you rely on it and would like to take over maintenance, we'd be glad to help hand it off — please open an issue at https://github.com/autopkg/zentral-recipes/issues to get in touch.</string>
+                        </dict>
+                </dict>
             <dict>
                 <key>Processor</key>
                 <string>GitHubReleasesInfoProvider</string>

--- a/tailwindcss/tailwindcss-cli.install.recipe
+++ b/tailwindcss/tailwindcss-cli.install.recipe
@@ -19,6 +19,15 @@
     <array>
         <dict>
             <key>Processor</key>
+            <string>DeprecationWarning</string>
+            <key>Arguments</key>
+            <dict>
+                <key>warning_message</key>
+                <string>This recipe is deprecated and is no longer maintained by Zentral. It may stop working at any time and will not receive further updates. If you rely on it and would like to take over maintenance, we'd be glad to help hand it off — please open an issue at https://github.com/autopkg/zentral-recipes/issues to get in touch.</string>
+            </dict>
+        </dict>
+        <dict>
+            <key>Processor</key>
             <string>Installer</string>
         </dict>
     </array>

--- a/tailwindcss/tailwindcss-cli.munki.recipe
+++ b/tailwindcss/tailwindcss-cli.munki.recipe
@@ -46,6 +46,15 @@
     <array>
         <dict>
             <key>Processor</key>
+            <string>DeprecationWarning</string>
+            <key>Arguments</key>
+            <dict>
+                <key>warning_message</key>
+                <string>This recipe is deprecated and is no longer maintained by Zentral. It may stop working at any time and will not receive further updates. If you rely on it and would like to take over maintenance, we'd be glad to help hand it off — please open an issue at https://github.com/autopkg/zentral-recipes/issues to get in touch.</string>
+            </dict>
+        </dict>
+        <dict>
+            <key>Processor</key>
             <string>MunkiImporter</string>
             <key>Arguments</key>
             <dict>

--- a/tailwindcss/tailwindcss-cli.pkg.recipe
+++ b/tailwindcss/tailwindcss-cli.pkg.recipe
@@ -21,6 +21,15 @@
         <string>com.github.zentralpro.download.tailwindcss-cli</string>
         <key>Process</key>
         <array>
+                <dict>
+                        <key>Processor</key>
+                        <string>DeprecationWarning</string>
+                        <key>Arguments</key>
+                        <dict>
+                                <key>warning_message</key>
+                                <string>This recipe is deprecated and is no longer maintained by Zentral. It may stop working at any time and will not receive further updates. If you rely on it and would like to take over maintenance, we'd be glad to help hand it off — please open an issue at https://github.com/autopkg/zentral-recipes/issues to get in touch.</string>
+                        </dict>
+                </dict>
             <dict>
                 <key>Processor</key>
                 <string>PkgRootCreator</string>

--- a/tcscertrequest/tcscertrequest.download.recipe
+++ b/tcscertrequest/tcscertrequest.download.recipe
@@ -20,6 +20,15 @@
     <key>Process</key>
     <array>
         <dict>
+            <key>Processor</key>
+            <string>DeprecationWarning</string>
+            <key>Arguments</key>
+            <dict>
+                <key>warning_message</key>
+                <string>This recipe is deprecated and is no longer maintained by Zentral. It may stop working at any time and will not receive further updates. If you rely on it and would like to take over maintenance, we'd be glad to help hand it off — please open an issue at https://github.com/autopkg/zentral-recipes/issues to get in touch.</string>
+            </dict>
+        </dict>
+        <dict>
           <key>Processor</key>
           <string>URLTextSearcher</string>
           <key>Arguments</key>

--- a/tcscertrequest/tcscertrequest.install.recipe
+++ b/tcscertrequest/tcscertrequest.install.recipe
@@ -16,6 +16,15 @@
     <array>
         <dict>
             <key>Processor</key>
+            <string>DeprecationWarning</string>
+            <key>Arguments</key>
+            <dict>
+                <key>warning_message</key>
+                <string>This recipe is deprecated and is no longer maintained by Zentral. It may stop working at any time and will not receive further updates. If you rely on it and would like to take over maintenance, we'd be glad to help hand it off — please open an issue at https://github.com/autopkg/zentral-recipes/issues to get in touch.</string>
+            </dict>
+        </dict>
+        <dict>
+            <key>Processor</key>
             <string>Installer</string>
             <key>Arguments</key>
             <dict>

--- a/tcscertrequest/tcscertrequest.munki.recipe
+++ b/tcscertrequest/tcscertrequest.munki.recipe
@@ -44,6 +44,15 @@
     </dict>
     <key>Process</key>
     <array>
+        <dict>
+            <key>Processor</key>
+            <string>DeprecationWarning</string>
+            <key>Arguments</key>
+            <dict>
+                <key>warning_message</key>
+                <string>This recipe is deprecated and is no longer maintained by Zentral. It may stop working at any time and will not receive further updates. If you rely on it and would like to take over maintenance, we'd be glad to help hand it off — please open an issue at https://github.com/autopkg/zentral-recipes/issues to get in touch.</string>
+            </dict>
+        </dict>
         <!-- NOTE!
           Make sure we have the correct version, not accidentally the version of the pkg itself
         -->

--- a/vector/vector.download.recipe
+++ b/vector/vector.download.recipe
@@ -19,6 +19,15 @@
         <string>1.0.0</string>
         <key>Process</key>
         <array>
+                <dict>
+                        <key>Processor</key>
+                        <string>DeprecationWarning</string>
+                        <key>Arguments</key>
+                        <dict>
+                                <key>warning_message</key>
+                                <string>This recipe is deprecated and is no longer maintained by Zentral. It may stop working at any time and will not receive further updates. If you rely on it and would like to take over maintenance, we'd be glad to help hand it off — please open an issue at https://github.com/autopkg/zentral-recipes/issues to get in touch.</string>
+                        </dict>
+                </dict>
             <dict>
                 <key>Processor</key>
                 <string>GitHubReleasesInfoProvider</string>

--- a/vector/vector.install.recipe
+++ b/vector/vector.install.recipe
@@ -19,6 +19,15 @@
     <array>
         <dict>
             <key>Processor</key>
+            <string>DeprecationWarning</string>
+            <key>Arguments</key>
+            <dict>
+                <key>warning_message</key>
+                <string>This recipe is deprecated and is no longer maintained by Zentral. It may stop working at any time and will not receive further updates. If you rely on it and would like to take over maintenance, we'd be glad to help hand it off — please open an issue at https://github.com/autopkg/zentral-recipes/issues to get in touch.</string>
+            </dict>
+        </dict>
+        <dict>
+            <key>Processor</key>
             <string>Installer</string>
         </dict>
     </array>

--- a/vector/vector.munki.recipe
+++ b/vector/vector.munki.recipe
@@ -46,6 +46,15 @@
     <array>
         <dict>
             <key>Processor</key>
+            <string>DeprecationWarning</string>
+            <key>Arguments</key>
+            <dict>
+                <key>warning_message</key>
+                <string>This recipe is deprecated and is no longer maintained by Zentral. It may stop working at any time and will not receive further updates. If you rely on it and would like to take over maintenance, we'd be glad to help hand it off — please open an issue at https://github.com/autopkg/zentral-recipes/issues to get in touch.</string>
+            </dict>
+        </dict>
+        <dict>
+            <key>Processor</key>
             <string>MunkiImporter</string>
             <key>Arguments</key>
             <dict>

--- a/vector/vector.pkg.recipe
+++ b/vector/vector.pkg.recipe
@@ -21,6 +21,15 @@
         <string>com.github.zentralpro.download.vector</string>
         <key>Process</key>
         <array>
+                <dict>
+                        <key>Processor</key>
+                        <string>DeprecationWarning</string>
+                        <key>Arguments</key>
+                        <dict>
+                                <key>warning_message</key>
+                                <string>This recipe is deprecated and is no longer maintained by Zentral. It may stop working at any time and will not receive further updates. If you rely on it and would like to take over maintenance, we'd be glad to help hand it off — please open an issue at https://github.com/autopkg/zentral-recipes/issues to get in touch.</string>
+                        </dict>
+                </dict>
             <dict>
                 <key>Processor</key>
                 <string>PkgRootCreator</string>

--- a/yubiswitch/yubiswitch.download.recipe
+++ b/yubiswitch/yubiswitch.download.recipe
@@ -19,6 +19,15 @@
     <array>
         <dict>
             <key>Processor</key>
+            <string>DeprecationWarning</string>
+            <key>Arguments</key>
+            <dict>
+                <key>warning_message</key>
+                <string>This recipe is deprecated and is no longer maintained by Zentral. It may stop working at any time and will not receive further updates. If you rely on it and would like to take over maintenance, we'd be glad to help hand it off — please open an issue at https://github.com/autopkg/zentral-recipes/issues to get in touch.</string>
+            </dict>
+        </dict>
+        <dict>
+            <key>Processor</key>
             <string>GitHubReleasesInfoProvider</string>
             <key>Arguments</key>
             <dict>

--- a/yubiswitch/yubiswitch.install.recipe
+++ b/yubiswitch/yubiswitch.install.recipe
@@ -19,6 +19,15 @@
     <array>
         <dict>
             <key>Processor</key>
+            <string>DeprecationWarning</string>
+            <key>Arguments</key>
+            <dict>
+                <key>warning_message</key>
+                <string>This recipe is deprecated and is no longer maintained by Zentral. It may stop working at any time and will not receive further updates. If you rely on it and would like to take over maintenance, we'd be glad to help hand it off — please open an issue at https://github.com/autopkg/zentral-recipes/issues to get in touch.</string>
+            </dict>
+        </dict>
+        <dict>
+            <key>Processor</key>
             <string>InstallFromDMG</string>
 						<key>Arguments</key>
 						<dict>

--- a/yubiswitch/yubiswitch.munki.recipe
+++ b/yubiswitch/yubiswitch.munki.recipe
@@ -44,6 +44,15 @@
     <array>
         <dict>
             <key>Processor</key>
+            <string>DeprecationWarning</string>
+            <key>Arguments</key>
+            <dict>
+                <key>warning_message</key>
+                <string>This recipe is deprecated and is no longer maintained by Zentral. It may stop working at any time and will not receive further updates. If you rely on it and would like to take over maintenance, we'd be glad to help hand it off — please open an issue at https://github.com/autopkg/zentral-recipes/issues to get in touch.</string>
+            </dict>
+        </dict>
+        <dict>
+            <key>Processor</key>
             <string>MunkiImporter</string>
             <key>Arguments</key>
             <dict>


### PR DESCRIPTION
Add a DeprecationWarning processor to every recipe except the titles we still use ourselves (DrataAgent, osquery-extension, Privileges, santa, santa-lite, turbo, zentral_enrollpkgs). The warning invites anyone who relies on a deprecated recipe to open an issue and take over maintenance.

The pre-existing, replacement-pointing messages for yq and YubiKey_Manager are kept; YubiKey_Manager's install/munki recipes now carry the same detailed EOL message as its download recipe.

Also add a deprecation notice to the README.