### PR TITLE
Point deprecated swiftDialog, mist, and Proxyman recipes at their new…

### DIFF
--- a/Proxyman/Proxyman.download.recipe
+++ b/Proxyman/Proxyman.download.recipe
@@ -25,7 +25,7 @@
             <key>Arguments</key>
             <dict>
                 <key>warning_message</key>
-                <string>This recipe is deprecated and is no longer maintained by Zentral. It may stop working at any time and will not receive further updates. If you rely on it and would like to take over maintenance, we'd be glad to help hand it off — please open an issue at https://github.com/autopkg/zentral-recipes/issues to get in touch.</string>
+                <string>This recipe is deprecated and no longer maintained by Zentral. It has been adopted by aanklewicz-recipes: use com.github.aanklewicz.download.Proxyman from https://github.com/autopkg/aanklewicz-recipes instead.</string>
             </dict>
         </dict>
         <dict>

--- a/Proxyman/Proxyman.install.recipe
+++ b/Proxyman/Proxyman.install.recipe
@@ -20,7 +20,7 @@
             <key>Arguments</key>
             <dict>
                 <key>warning_message</key>
-                <string>This recipe is deprecated and is no longer maintained by Zentral. It may stop working at any time and will not receive further updates. If you rely on it and would like to take over maintenance, we'd be glad to help hand it off — please open an issue at https://github.com/autopkg/zentral-recipes/issues to get in touch.</string>
+                <string>This recipe is deprecated and no longer maintained by Zentral. It has been adopted by aanklewicz-recipes: use com.github.aanklewicz.install.Proxyman from https://github.com/autopkg/aanklewicz-recipes instead.</string>
             </dict>
         </dict>
         <dict>

--- a/Proxyman/Proxyman.munki.recipe
+++ b/Proxyman/Proxyman.munki.recipe
@@ -50,7 +50,7 @@
             <key>Arguments</key>
             <dict>
                 <key>warning_message</key>
-                <string>This recipe is deprecated and is no longer maintained by Zentral. It may stop working at any time and will not receive further updates. If you rely on it and would like to take over maintenance, we'd be glad to help hand it off — please open an issue at https://github.com/autopkg/zentral-recipes/issues to get in touch.</string>
+                <string>This recipe is deprecated and no longer maintained by Zentral. It has been adopted by aanklewicz-recipes: use com.github.aanklewicz.munki.Proxyman from https://github.com/autopkg/aanklewicz-recipes instead.</string>
             </dict>
         </dict>
         <dict>

--- a/Proxyman/Proxyman.pkg.recipe
+++ b/Proxyman/Proxyman.pkg.recipe
@@ -23,7 +23,7 @@
             <key>Arguments</key>
             <dict>
                 <key>warning_message</key>
-                <string>This recipe is deprecated and is no longer maintained by Zentral. It may stop working at any time and will not receive further updates. If you rely on it and would like to take over maintenance, we'd be glad to help hand it off — please open an issue at https://github.com/autopkg/zentral-recipes/issues to get in touch.</string>
+                <string>This recipe is deprecated and no longer maintained by Zentral. It has been adopted by aanklewicz-recipes: use com.github.aanklewicz.pkg.Proxyman from https://github.com/autopkg/aanklewicz-recipes instead.</string>
             </dict>
         </dict>
         <dict>

--- a/README.md
+++ b/README.md
@@ -28,3 +28,15 @@ If you rely on one of the deprecated recipes and would like to take over its
 maintenance, we'd be glad to help hand it off — please
 [open an issue](https://github.com/autopkg/zentral-recipes/issues) to get in
 touch.
+
+### Adopted recipes
+
+The following deprecated recipes have been adopted and are maintained
+elsewhere — please update your overrides to point at their new homes:
+
+| Recipe | New home |
+| --- | --- |
+| `mist` (download, munki, install) | [autopkg/aanklewicz-recipes](https://github.com/autopkg/aanklewicz-recipes) (`com.github.aanklewicz.*.mist`) |
+| `Proxyman` (download, munki, pkg, install) | [autopkg/aanklewicz-recipes](https://github.com/autopkg/aanklewicz-recipes) (`com.github.aanklewicz.*.Proxyman`) |
+| `swiftDialog.download` | [autopkg/smithjw-recipes](https://github.com/autopkg/smithjw-recipes) (`com.github.smithjw.download.swiftDialog`) |
+| `swiftDialog.munki` | [autopkg/aanklewicz-recipes](https://github.com/autopkg/aanklewicz-recipes) (`com.github.aanklewicz.munki.swiftDialog`, parented on the smithjw download recipe) |

--- a/mist/mist.download.recipe
+++ b/mist/mist.download.recipe
@@ -23,7 +23,7 @@
                         <key>Arguments</key>
                         <dict>
                                 <key>warning_message</key>
-                                <string>This recipe is deprecated and is no longer maintained by Zentral. It may stop working at any time and will not receive further updates. If you rely on it and would like to take over maintenance, we'd be glad to help hand it off — please open an issue at https://github.com/autopkg/zentral-recipes/issues to get in touch.</string>
+                                <string>This recipe is deprecated and no longer maintained by Zentral. It has been adopted by aanklewicz-recipes: use com.github.aanklewicz.download.mist from https://github.com/autopkg/aanklewicz-recipes instead.</string>
                         </dict>
                 </dict>
             <dict>

--- a/mist/mist.install.recipe
+++ b/mist/mist.install.recipe
@@ -23,7 +23,7 @@
             <key>Arguments</key>
             <dict>
                 <key>warning_message</key>
-                <string>This recipe is deprecated and is no longer maintained by Zentral. It may stop working at any time and will not receive further updates. If you rely on it and would like to take over maintenance, we'd be glad to help hand it off — please open an issue at https://github.com/autopkg/zentral-recipes/issues to get in touch.</string>
+                <string>This recipe is deprecated and no longer maintained by Zentral. It has been adopted by aanklewicz-recipes: use com.github.aanklewicz.install.mist from https://github.com/autopkg/aanklewicz-recipes instead.</string>
             </dict>
         </dict>
         <dict>

--- a/mist/mist.munki.recipe
+++ b/mist/mist.munki.recipe
@@ -58,7 +58,7 @@ Set the DERIVE_MIN_OS variable to a non-empty string to set the minimum_os_versi
             <key>Arguments</key>
             <dict>
                 <key>warning_message</key>
-                <string>This recipe is deprecated and is no longer maintained by Zentral. It may stop working at any time and will not receive further updates. If you rely on it and would like to take over maintenance, we'd be glad to help hand it off — please open an issue at https://github.com/autopkg/zentral-recipes/issues to get in touch.</string>
+                <string>This recipe is deprecated and no longer maintained by Zentral. It has been adopted by aanklewicz-recipes: use com.github.aanklewicz.munki.mist from https://github.com/autopkg/aanklewicz-recipes instead.</string>
             </dict>
         </dict>
         <dict>

--- a/swiftDialog/swiftDialog.download.recipe
+++ b/swiftDialog/swiftDialog.download.recipe
@@ -23,7 +23,7 @@
                         <key>Arguments</key>
                         <dict>
                                 <key>warning_message</key>
-                                <string>This recipe is deprecated and is no longer maintained by Zentral. It may stop working at any time and will not receive further updates. If you rely on it and would like to take over maintenance, we'd be glad to help hand it off — please open an issue at https://github.com/autopkg/zentral-recipes/issues to get in touch.</string>
+                                <string>This recipe is deprecated and no longer maintained by Zentral. An actively maintained swiftDialog download recipe is available in smithjw-recipes: use com.github.smithjw.download.swiftDialog from https://github.com/autopkg/smithjw-recipes instead.</string>
                         </dict>
                 </dict>
             <dict>

--- a/swiftDialog/swiftDialog.install.recipe
+++ b/swiftDialog/swiftDialog.install.recipe
@@ -23,7 +23,7 @@
             <key>Arguments</key>
             <dict>
                 <key>warning_message</key>
-                <string>This recipe is deprecated and is no longer maintained by Zentral. It may stop working at any time and will not receive further updates. If you rely on it and would like to take over maintenance, we'd be glad to help hand it off — please open an issue at https://github.com/autopkg/zentral-recipes/issues to get in touch.</string>
+                <string>This recipe is deprecated and no longer maintained by Zentral. It may stop working at any time. For a maintained download recipe to parent an install recipe on, see com.github.smithjw.download.swiftDialog in https://github.com/autopkg/smithjw-recipes.</string>
             </dict>
         </dict>
         <dict>

--- a/swiftDialog/swiftDialog.jamf.recipe
+++ b/swiftDialog/swiftDialog.jamf.recipe
@@ -43,7 +43,7 @@
                         <key>Arguments</key>
                         <dict>
                                 <key>warning_message</key>
-                                <string>This recipe is deprecated and is no longer maintained by Zentral. It may stop working at any time and will not receive further updates. If you rely on it and would like to take over maintenance, we'd be glad to help hand it off — please open an issue at https://github.com/autopkg/zentral-recipes/issues to get in touch.</string>
+                                <string>This recipe is deprecated and no longer maintained by Zentral. It may stop working at any time. For a maintained download recipe to parent a jamf recipe on, see com.github.smithjw.download.swiftDialog in https://github.com/autopkg/smithjw-recipes.</string>
                         </dict>
                 </dict>
             <dict>

--- a/swiftDialog/swiftDialog.munki.recipe
+++ b/swiftDialog/swiftDialog.munki.recipe
@@ -51,7 +51,7 @@
                         <key>Arguments</key>
                         <dict>
                                 <key>warning_message</key>
-                                <string>This recipe is deprecated and is no longer maintained by Zentral. It may stop working at any time and will not receive further updates. If you rely on it and would like to take over maintenance, we'd be glad to help hand it off — please open an issue at https://github.com/autopkg/zentral-recipes/issues to get in touch.</string>
+                                <string>This recipe is deprecated and no longer maintained by Zentral. A replacement munki recipe is available in aanklewicz-recipes: use com.github.aanklewicz.munki.swiftDialog from https://github.com/autopkg/aanklewicz-recipes (parented on com.github.smithjw.download.swiftDialog) instead.</string>
                         </dict>
                 </dict>
             <dict>


### PR DESCRIPTION
… homes

Per #70: mist and Proxyman have been adopted into autopkg/aanklewicz-recipes; swiftDialog download is maintained in autopkg/smithjw-recipes, with a replacement munki recipe in autopkg/aanklewicz-recipes. Update the README and each DeprecationWarning message to direct users to the new locations.