### PR TITLE
Quote Santa Lite launchctl user argument

### DIFF
--- a/santa-lite/santa-lite.munki.recipe
+++ b/santa-lite/santa-lite.munki.recipe
@@ -56,7 +56,7 @@
 /bin/launchctl remove com.northpolesec.santa.syncservice
 sleep 1
 user=$(/usr/bin/stat -f '%u' /dev/console)
-[[ -n "$user" ]] &amp;&amp; /bin/launchctl asuser ${user} /bin/launchctl remove com.northpolesec.santa
+[[ -n "$user" ]] &amp;&amp; /bin/launchctl asuser "${user}" /bin/launchctl remove com.northpolesec.santa
 # and to clean out the log config, although it won't write after wiping the binary
 /usr/bin/killall -HUP syslogd
 # delete artifacts on-disk


### PR DESCRIPTION
Quote the console UID when unloading the GUI agent so launchctl receives the intended asuser argument.